### PR TITLE
Worktree-find-in-book

### DIFF
--- a/src/components/editor/Editor.tsx
+++ b/src/components/editor/Editor.tsx
@@ -580,6 +580,9 @@ interface EditorProps {
 export default function Editor({ onWordCountChange, onVimModeChange, onEditorView }: EditorProps) {
   // Use selectors to avoid re-renders on unrelated store changes
   const activeStoryletId = useStoryletStore((s) => s.activeStoryletId)
+  const activeDocVersion = useStoryletStore(
+    (s) => s.book?.storylets.find((sl) => sl.id === s.activeStoryletId)?.docVersion ?? 0
+  )
   const fontFamily = useEditorStore((s) => s.fontFamily)
   const fontSize = useEditorStore((s) => s.fontSize)
   const renderMode = useEditorStore((s) => s.renderMode)
@@ -589,7 +592,10 @@ export default function Editor({ onWordCountChange, onVimModeChange, onEditorVie
 
   const containerRef = useRef<HTMLDivElement>(null)
   const viewRef = useRef<EditorView | null>(null)
-  const loadedDocumentRef = useRef<string | null>(null)
+  // Tracks which storylet (id + docVersion) is currently loaded into the EditorView.
+  // docVersion lets external bulk mutations (e.g. Find-in-Book replace) force a reload
+  // even when the active id is unchanged.
+  const loadedDocumentRef = useRef<{ id: string; version: number } | null>(null)
   const fontCompartmentRef = useRef<Compartment | null>(null)
   const fontSizeCompartmentRef = useRef<Compartment | null>(null)
   const typewriterCompartmentRef = useRef<Compartment | null>(null)
@@ -791,9 +797,9 @@ export default function Editor({ onWordCountChange, onVimModeChange, onEditorVie
     if (activeStorylet?.content) {
       view.dispatch({ changes: { from: 0, to: 0, insert: activeStorylet.content } })
       callbacksRef.current.onWordCountChange?.(countWords(activeStorylet.content))
-      loadedDocumentRef.current = activeStorylet.id
+      loadedDocumentRef.current = { id: activeStorylet.id, version: activeStorylet.docVersion ?? 0 }
     } else if (activeStorylet) {
-      loadedDocumentRef.current = activeStorylet.id
+      loadedDocumentRef.current = { id: activeStorylet.id, version: activeStorylet.docVersion ?? 0 }
     }
 
     return () => {
@@ -814,9 +820,11 @@ export default function Editor({ onWordCountChange, onVimModeChange, onEditorVie
     const store = useStoryletStore.getState()
     const activeStorylet = store.book?.storylets?.find((s) => s.id === store.activeStoryletId)
     if (!activeStorylet) return
-    if (loadedDocumentRef.current === activeStorylet.id) return
+    const currentVersion = activeStorylet.docVersion ?? 0
+    const loaded = loadedDocumentRef.current
+    if (loaded && loaded.id === activeStorylet.id && loaded.version === currentVersion) return
 
-    loadedDocumentRef.current = activeStorylet.id
+    loadedDocumentRef.current = { id: activeStorylet.id, version: currentVersion }
     const content = activeStorylet.content ?? ''
     view.dispatch({
       changes: { from: 0, to: view.state.doc.length, insert: content },
@@ -830,7 +838,7 @@ export default function Editor({ onWordCountChange, onVimModeChange, onEditorVie
     if (view) {
       dispatchStatblockActiveStorylet(view, activeStoryletId ?? '')
     }
-  }, [activeStoryletId, loadStorylet])
+  }, [activeStoryletId, activeDocVersion, loadStorylet])
 
   // Update font family
   useEffect(() => {

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback, useEffect, useRef, useMemo } from 'react'
 import type { EditorView } from '@codemirror/view'
-import { Coins } from 'lucide-react'
+import { Coins, Search } from 'lucide-react'
 import { Sidebar } from '../sidebar/Sidebar'
 import Editor from '../editor/Editor'
 import BubbleToolbar from '../editor/BubbleToolbar'
@@ -14,6 +14,7 @@ import { quickSave, saveAsNewFile } from '../../lib/fileSystem'
 import { createSnapshot } from '../../stores/snapshotStore'
 import { useKeybindingStore, matchesEvent } from '../../stores/keybindingStore'
 import { SnapshotBrowser } from './SnapshotBrowser'
+import { FindInBook } from './FindInBook'
 import { PublishedSnapshotsBrowser } from './PublishedSnapshotsBrowser'
 import { PublishModal } from './PublishModal'
 import { StyleEditor } from '../editor/StyleEditor'
@@ -43,6 +44,7 @@ export function AppShell() {
   const [editorView, setEditorView] = useState<EditorView | null>(null)
   const editorViewRef = useRef<EditorView | null>(null)
   const [snapshotsOpen, setSnapshotsOpen] = useState(false)
+  const [findOpen, setFindOpen] = useState(false)
   const [publishedSnapshotsOpen, setPublishedSnapshotsOpen] = useState(false)
   const [publishModalOpen, setPublishModalOpen] = useState(false)
   const [styleEditorOpen, setStyleEditorOpen] = useState(false)
@@ -161,6 +163,11 @@ export function AppShell() {
       if (matchesEvent(km.toggleTypewriter, e)) {
         e.preventDefault()
         toggleDistractionFree()
+        return
+      }
+      if (km.findInBook && matchesEvent(km.findInBook, e)) {
+        e.preventDefault()
+        setFindOpen((prev) => !prev)
         return
       }
       if (matchesEvent(km.snapshotHistory, e)) {
@@ -398,6 +405,13 @@ export function AppShell() {
               Publish
             </button>
             <button
+              onClick={() => setFindOpen((prev) => !prev)}
+              className="text-gray-500 hover:text-gray-300 transition-colors px-1.5 py-0.5"
+              title="Find in book (Ctrl+Shift+F)"
+            >
+              <Search size={13} />
+            </button>
+            <button
               onClick={() => {
                 setSnapshotsOpen((prev) => !prev)
                 setPublishedSnapshotsOpen(false)
@@ -436,6 +450,11 @@ export function AppShell() {
             open={snapshotsOpen}
             onClose={() => setSnapshotsOpen(false)}
             onRestore={handleRestoreSnapshot}
+          />
+          <FindInBook
+            open={findOpen}
+            onClose={() => setFindOpen(false)}
+            editorView={editorView}
           />
           <PublishModal
             open={publishModalOpen}

--- a/src/components/layout/FindInBook.tsx
+++ b/src/components/layout/FindInBook.tsx
@@ -1,8 +1,15 @@
 import { useState, useEffect, useRef, useMemo } from 'react'
 import type { EditorView } from '@codemirror/view'
 import { useStoryletStore } from '../../stores/storyletStore'
-import { compileQuery, searchBook } from '../../lib/bookSearch'
-import type { SearchOptions, StoryletSearchResult } from '../../types'
+import { compileQuery, computeReplacePreview, searchBook } from '../../lib/bookSearch'
+import { snapshotBook } from '../../stores/snapshotStore'
+import type {
+  ReplacePreview,
+  ReplaceScope,
+  SearchOptions,
+  StoryletSearchResult,
+} from '../../types'
+import { ReplacePreviewModal } from './ReplacePreviewModal'
 
 interface Props {
   open: boolean
@@ -22,6 +29,12 @@ export function FindInBook({ open, onClose, editorView }: Props) {
   const [wholeWord, setWholeWord] = useState(false)
   const [regex, setRegex] = useState(false)
   const [debouncedQuery, setDebouncedQuery] = useState('')
+  const [replacement, setReplacement] = useState('')
+  const [scope, setScope] = useState<ReplaceScope>('book')
+  const [previewOpen, setPreviewOpen] = useState(false)
+  const [previews, setPreviews] = useState<ReplacePreview[]>([])
+  const [submitting, setSubmitting] = useState(false)
+  const [successMessage, setSuccessMessage] = useState<string | null>(null)
 
   // Debounce query (150ms)
   useEffect(() => {
@@ -47,9 +60,10 @@ export function FindInBook({ open, onClose, editorView }: Props) {
     return () => document.removeEventListener('keydown', onKey)
   }, [open, onClose])
 
-  // Click outside to close
+  // Click outside to close — but ignore clicks while preview modal is open
+  // (the modal sits at z-[60] above this panel and clicking it shouldn't dismiss find).
   useEffect(() => {
-    if (!open) return
+    if (!open || previewOpen) return
     function onClick(e: MouseEvent) {
       if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
         onClose()
@@ -57,7 +71,12 @@ export function FindInBook({ open, onClose, editorView }: Props) {
     }
     document.addEventListener('mousedown', onClick)
     return () => document.removeEventListener('mousedown', onClick)
-  }, [open, onClose])
+  }, [open, onClose, previewOpen])
+
+  // Clear stale success message whenever query/replacement/scope changes
+  useEffect(() => {
+    setSuccessMessage(null)
+  }, [query, replacement, scope, caseSensitive, wholeWord, regex])
 
   const options = useMemo<SearchOptions>(() => ({
     query: debouncedQuery,
@@ -84,6 +103,43 @@ export function FindInBook({ open, onClose, editorView }: Props) {
     () => results.reduce((sum, r) => sum + r.matches.length, 0),
     [results]
   )
+
+  function handleOpenPreview() {
+    if (!book || !hasQuery || compileError) return
+    const computed = computeReplacePreview(
+      book,
+      options,
+      replacement,
+      scope,
+      scope === 'storylet' ? activeStoryletId ?? undefined : undefined,
+    )
+    setPreviews(computed)
+    setSuccessMessage(null)
+    setPreviewOpen(true)
+  }
+
+  async function handleConfirmReplace() {
+    if (submitting) return
+    const currentBook = useStoryletStore.getState().book
+    if (!currentBook) return
+    setSubmitting(true)
+    try {
+      await snapshotBook(currentBook, 'bulkReplace')
+      const result = useStoryletStore.getState().replaceAllInBook(
+        options,
+        replacement,
+        scope,
+        scope === 'storylet' ? activeStoryletId ?? undefined : undefined,
+      )
+      setPreviewOpen(false)
+      setPreviews([])
+      setSuccessMessage(
+        `Replaced ${result.matchesReplaced} ${result.matchesReplaced === 1 ? 'match' : 'matches'} in ${result.storyletsChanged} ${result.storyletsChanged === 1 ? 'storylet' : 'storylets'}. Snapshot saved.`,
+      )
+    } finally {
+      setSubmitting(false)
+    }
+  }
 
   function handleJump(storyletId: string, start: number) {
     if (!editorView) return
@@ -163,6 +219,60 @@ export function FindInBook({ open, onClose, editorView }: Props) {
         )}
       </div>
 
+      {/* Replace controls */}
+      <div className="px-4 py-3 border-b border-gray-700 flex flex-col gap-2">
+        <input
+          type="text"
+          value={replacement}
+          onChange={(e) => setReplacement(e.target.value)}
+          placeholder="Replace with..."
+          className="bg-gray-800 border border-gray-700 rounded px-2 py-1.5 text-sm text-white outline-none focus:border-blue-500 w-full"
+        />
+        <div className="flex items-center gap-1.5">
+          <div className="flex bg-gray-800 rounded overflow-hidden border border-gray-700 text-[11px]">
+            <button
+              type="button"
+              onClick={() => setScope('storylet')}
+              disabled={!activeStoryletId}
+              className={`px-2 py-1 transition-colors ${
+                scope === 'storylet'
+                  ? 'bg-emerald-700 text-white'
+                  : 'text-gray-400 hover:bg-gray-700 hover:text-gray-200'
+              } disabled:opacity-40 disabled:cursor-not-allowed`}
+              title="Replace only in the active storylet"
+            >
+              This storylet
+            </button>
+            <button
+              type="button"
+              onClick={() => setScope('book')}
+              className={`px-2 py-1 transition-colors ${
+                scope === 'book'
+                  ? 'bg-emerald-700 text-white'
+                  : 'text-gray-400 hover:bg-gray-700 hover:text-gray-200'
+              }`}
+              title="Replace in every storylet"
+            >
+              Whole book
+            </button>
+          </div>
+          <button
+            type="button"
+            onClick={handleOpenPreview}
+            disabled={!hasQuery || !!compileError || results.length === 0}
+            className="ml-auto px-2.5 py-1 rounded text-[11px] font-medium bg-emerald-700 hover:bg-emerald-600 disabled:opacity-40 disabled:cursor-not-allowed text-white transition-colors"
+          >
+            Replace
+          </button>
+        </div>
+        {successMessage && (
+          <div className="text-xs text-emerald-400 mt-1">
+            {successMessage}{' '}
+            <span className="text-gray-500">Open History to revert.</span>
+          </div>
+        )}
+      </div>
+
       {/* Results */}
       <div className="flex-1 overflow-y-auto">
         {!hasQuery ? (
@@ -203,6 +313,16 @@ export function FindInBook({ open, onClose, editorView }: Props) {
           ))
         )}
       </div>
+
+      <ReplacePreviewModal
+        open={previewOpen}
+        onClose={() => {
+          if (!submitting) setPreviewOpen(false)
+        }}
+        onConfirm={() => void handleConfirmReplace()}
+        previews={previews}
+        submitting={submitting}
+      />
     </div>
   )
 }

--- a/src/components/layout/FindInBook.tsx
+++ b/src/components/layout/FindInBook.tsx
@@ -1,0 +1,232 @@
+import { useState, useEffect, useRef, useMemo } from 'react'
+import type { EditorView } from '@codemirror/view'
+import { useStoryletStore } from '../../stores/storyletStore'
+import { compileQuery, searchBook } from '../../lib/bookSearch'
+import type { SearchOptions, StoryletSearchResult } from '../../types'
+
+interface Props {
+  open: boolean
+  onClose: () => void
+  editorView: EditorView | null
+}
+
+export function FindInBook({ open, onClose, editorView }: Props) {
+  const panelRef = useRef<HTMLDivElement>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
+  const book = useStoryletStore((s) => s.book)
+  const activeStoryletId = useStoryletStore((s) => s.activeStoryletId)
+  const setActiveStorylet = useStoryletStore((s) => s.setActiveStorylet)
+
+  const [query, setQuery] = useState('')
+  const [caseSensitive, setCaseSensitive] = useState(false)
+  const [wholeWord, setWholeWord] = useState(false)
+  const [regex, setRegex] = useState(false)
+  const [debouncedQuery, setDebouncedQuery] = useState('')
+
+  // Debounce query (150ms)
+  useEffect(() => {
+    const handle = setTimeout(() => setDebouncedQuery(query), 150)
+    return () => clearTimeout(handle)
+  }, [query])
+
+  // Autofocus on open
+  useEffect(() => {
+    if (open) {
+      // Defer to next tick so the panel is mounted before focusing
+      setTimeout(() => inputRef.current?.focus(), 0)
+    }
+  }, [open])
+
+  // ESC to close
+  useEffect(() => {
+    if (!open) return
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') { e.preventDefault(); onClose() }
+    }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [open, onClose])
+
+  // Click outside to close
+  useEffect(() => {
+    if (!open) return
+    function onClick(e: MouseEvent) {
+      if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
+        onClose()
+      }
+    }
+    document.addEventListener('mousedown', onClick)
+    return () => document.removeEventListener('mousedown', onClick)
+  }, [open, onClose])
+
+  const options = useMemo<SearchOptions>(() => ({
+    query: debouncedQuery,
+    caseSensitive,
+    wholeWord,
+    regex,
+  }), [debouncedQuery, caseSensitive, wholeWord, regex])
+
+  // Treat empty query as "no query entered" — never compile or search.
+  const hasQuery = debouncedQuery.length > 0
+
+  const compileError = useMemo<string | null>(() => {
+    if (!hasQuery) return null
+    const compiled = compileQuery(options)
+    return 'error' in compiled ? compiled.error : null
+  }, [options, hasQuery])
+
+  const results = useMemo<StoryletSearchResult[]>(() => {
+    if (!book || !hasQuery || compileError) return []
+    return searchBook(book, options)
+  }, [book, options, hasQuery, compileError])
+
+  const totalMatches = useMemo(
+    () => results.reduce((sum, r) => sum + r.matches.length, 0),
+    [results]
+  )
+
+  function handleJump(storyletId: string, start: number) {
+    if (!editorView) return
+    if (storyletId !== activeStoryletId) {
+      setActiveStorylet(storyletId)
+      setTimeout(() => {
+        const v = editorView
+        if (!v) return
+        const len = v.state.doc.length
+        const pos = Math.min(start, len)
+        v.dispatch({ selection: { anchor: pos }, scrollIntoView: true })
+        v.focus()
+      }, 30)
+    } else {
+      const len = editorView.state.doc.length
+      const pos = Math.min(start, len)
+      editorView.dispatch({ selection: { anchor: pos }, scrollIntoView: true })
+      editorView.focus()
+    }
+  }
+
+  if (!open) return null
+
+  return (
+    <div
+      ref={panelRef}
+      className="fixed right-0 top-0 bottom-0 z-50 w-[380px] max-w-[90vw] bg-gray-900 border-l border-gray-700 shadow-2xl flex flex-col"
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 py-3 border-b border-gray-700">
+        <span className="text-sm font-medium text-gray-200">Find in book</span>
+        <button
+          onClick={onClose}
+          className="text-gray-500 hover:text-gray-300 text-xs"
+        >
+          Close
+        </button>
+      </div>
+
+      {/* Search controls */}
+      <div className="px-4 py-3 border-b border-gray-700 flex flex-col gap-2">
+        <input
+          ref={inputRef}
+          type="text"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search the whole book..."
+          className="bg-gray-800 border border-gray-700 rounded px-2 py-1.5 text-sm text-white outline-none focus:border-blue-500 w-full"
+        />
+        <div className="flex items-center gap-1.5">
+          <ToggleButton
+            active={caseSensitive}
+            onClick={() => setCaseSensitive((v) => !v)}
+            title="Case sensitive"
+            label="Aa"
+          />
+          <ToggleButton
+            active={wholeWord}
+            onClick={() => setWholeWord((v) => !v)}
+            title="Whole word"
+            label="\b"
+          />
+          <ToggleButton
+            active={regex}
+            onClick={() => setRegex((v) => !v)}
+            title="Regular expression"
+            label=".*"
+          />
+        </div>
+        {compileError && (
+          <div className="text-xs text-red-400 mt-1">{compileError}</div>
+        )}
+        {hasQuery && !compileError && (
+          <div className="text-xs text-gray-500 mt-1">
+            {totalMatches} {totalMatches === 1 ? 'match' : 'matches'} in {results.length} {results.length === 1 ? 'storylet' : 'storylets'}
+          </div>
+        )}
+      </div>
+
+      {/* Results */}
+      <div className="flex-1 overflow-y-auto">
+        {!hasQuery ? (
+          <div className="px-4 py-8 text-center text-gray-500 text-sm">
+            Type a query to search the whole book.
+          </div>
+        ) : compileError ? null : results.length === 0 ? (
+          <div className="px-4 py-8 text-center text-gray-500 text-sm">
+            No matches.
+          </div>
+        ) : (
+          results.map((group) => (
+            <div key={group.storyletId} className="border-b border-gray-800">
+              <div className="px-4 py-1.5 bg-gray-800/50 text-[11px] font-medium text-gray-400 uppercase tracking-wider sticky top-0">
+                {group.storyletName}
+                <span className="ml-2 text-gray-600 normal-case tracking-normal">
+                  {group.matches.length}
+                </span>
+              </div>
+              {group.matches.map((m, idx) => {
+                const [hi, hj] = m.matchIndexInSnippet
+                const before = m.lineSnippet.slice(0, hi)
+                const hit = m.lineSnippet.slice(hi, hj)
+                const after = m.lineSnippet.slice(hj)
+                return (
+                  <button
+                    key={`${m.start}-${idx}`}
+                    onClick={() => handleJump(group.storyletId, m.start)}
+                    className="w-full text-left px-4 py-2 hover:bg-gray-800 border-b border-gray-800 transition-colors text-xs text-gray-400 font-mono whitespace-pre-wrap break-words"
+                  >
+                    <span className="text-gray-500">{before}</span>
+                    <span className="bg-yellow-500/30 text-yellow-100 rounded px-0.5">{hit}</span>
+                    <span className="text-gray-500">{after}</span>
+                  </button>
+                )
+              })}
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  )
+}
+
+interface ToggleButtonProps {
+  active: boolean
+  onClick: () => void
+  title: string
+  label: string
+}
+
+function ToggleButton({ active, onClick, title, label }: ToggleButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      title={title}
+      className={`px-2 py-1 rounded text-[11px] font-mono transition-colors ${
+        active
+          ? 'bg-emerald-700 text-white'
+          : 'bg-gray-800 text-gray-400 hover:bg-gray-700 hover:text-gray-200'
+      }`}
+    >
+      {label}
+    </button>
+  )
+}

--- a/src/components/layout/ReplacePreviewModal.tsx
+++ b/src/components/layout/ReplacePreviewModal.tsx
@@ -1,0 +1,159 @@
+import { useEffect, useRef, useCallback } from 'react'
+import type { ReplacePreview, ReplacePreviewMatch } from '../../types'
+
+interface Props {
+  open: boolean
+  onClose: () => void
+  onConfirm: () => void
+  previews: ReplacePreview[]
+  submitting?: boolean
+}
+
+export function ReplacePreviewModal({
+  open,
+  onClose,
+  onConfirm,
+  previews,
+  submitting = false,
+}: Props) {
+  const overlayRef = useRef<HTMLDivElement>(null)
+
+  // Escape closes
+  useEffect(() => {
+    if (!open) return
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        onClose()
+      }
+    }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [open, onClose])
+
+  const handleOverlayClick = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (e.target === overlayRef.current) onClose()
+    },
+    [onClose]
+  )
+
+  if (!open) return null
+
+  const totalMatches = previews.reduce((sum, p) => sum + p.matches.length, 0)
+  const storyletCount = previews.length
+  const noChanges = totalMatches === 0
+
+  return (
+    <div
+      ref={overlayRef}
+      className="fixed inset-0 z-[60] flex items-center justify-center bg-black/60"
+      onMouseDown={handleOverlayClick}
+    >
+      <div
+        className="bg-gray-900 border border-gray-700 rounded-lg shadow-2xl w-[640px] max-w-[calc(100vw-2rem)] max-h-[80vh] flex flex-col"
+        onMouseDown={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="px-5 py-4 border-b border-gray-700 flex items-center justify-between">
+          <h2 className="text-sm font-semibold text-gray-200">
+            {noChanges
+              ? 'No matches to replace'
+              : `Replace ${totalMatches} ${totalMatches === 1 ? 'match' : 'matches'} in ${storyletCount} ${storyletCount === 1 ? 'storylet' : 'storylets'}`}
+          </h2>
+          <button
+            onClick={onClose}
+            className="text-gray-500 hover:text-gray-300 text-xs"
+          >
+            Close
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="flex-1 overflow-y-auto px-5 py-4 flex flex-col gap-5">
+          {noChanges ? (
+            <div className="text-sm text-gray-500 text-center py-8">
+              The current search matches no content in the selected scope.
+            </div>
+          ) : (
+            previews.map((preview) => (
+              <PreviewSection key={preview.storyletId} preview={preview} />
+            ))
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="px-5 py-3 border-t border-gray-700 flex items-center justify-end gap-2">
+          <button
+            onClick={onClose}
+            className="px-3 py-1.5 text-sm text-gray-400 hover:text-gray-200 transition-colors rounded"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={onConfirm}
+            disabled={noChanges || submitting}
+            className="px-3 py-1.5 bg-emerald-700 hover:bg-emerald-600 disabled:opacity-40 disabled:cursor-not-allowed text-white rounded text-sm font-medium transition-colors"
+          >
+            {submitting ? 'Replacing…' : 'Replace & snapshot'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+interface PreviewSectionProps {
+  preview: ReplacePreview
+}
+
+function PreviewSection({ preview }: PreviewSectionProps) {
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="text-[11px] font-medium text-gray-400 uppercase tracking-wider flex items-center gap-2">
+        <span>{preview.storyletName}</span>
+        <span className="text-gray-600 normal-case tracking-normal">
+          {preview.matches.length} {preview.matches.length === 1 ? 'change' : 'changes'}
+        </span>
+      </div>
+      <div className="flex flex-col gap-1.5">
+        {preview.matches.map((m, idx) => (
+          <DiffRow key={`${m.start}-${idx}`} match={m} />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function DiffRow({ match }: { match: ReplacePreviewMatch }) {
+  const [bi, bj] = match.beforeMatchRange
+  const beforeBefore = match.beforeSnippet.slice(0, bi)
+  const beforeHit = match.beforeSnippet.slice(bi, bj)
+  const beforeAfter = match.beforeSnippet.slice(bj)
+
+  const [ai, aj] = match.afterReplacementRange
+  const afterBefore = match.afterSnippet.slice(0, ai)
+  const afterHit = match.afterSnippet.slice(ai, aj)
+  const afterAfter = match.afterSnippet.slice(aj)
+
+  return (
+    <div className="bg-gray-800/50 border border-gray-800 rounded px-3 py-2 font-mono text-xs flex flex-col gap-1">
+      <div className="flex items-start gap-2 whitespace-pre-wrap break-words">
+        <span className="text-red-400 select-none">−</span>
+        <div className="flex-1">
+          <span className="text-gray-500">{beforeBefore}</span>
+          <span className="bg-red-500/20 text-red-200 line-through rounded px-0.5">{beforeHit}</span>
+          <span className="text-gray-500">{beforeAfter}</span>
+        </div>
+      </div>
+      <div className="flex items-start gap-2 whitespace-pre-wrap break-words">
+        <span className="text-emerald-400 select-none">+</span>
+        <div className="flex-1">
+          <span className="text-gray-500">{afterBefore}</span>
+          <span className="bg-emerald-500/20 text-emerald-200 rounded px-0.5">{afterHit}</span>
+          <span className="text-gray-500">{afterAfter}</span>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/layout/ShortcutsMenu.tsx
+++ b/src/components/layout/ShortcutsMenu.tsx
@@ -16,6 +16,7 @@ const actionOrder: ActionName[] = [
   'snapshotHistory',
   'toggleCharacterPanel',
   'insertStatMarker',
+  'findInBook',
 ]
 
 const vimShortcuts = [

--- a/src/components/layout/SnapshotBrowser.tsx
+++ b/src/components/layout/SnapshotBrowser.tsx
@@ -9,6 +9,7 @@ const triggerLabel: Record<Snapshot['trigger'], string> = {
   switch: 'switch',
   auto: 'auto',
   closeBook: 'close',
+  bulkReplace: 'replace',
 }
 
 interface Props {

--- a/src/lib/bookSearch.ts
+++ b/src/lib/bookSearch.ts
@@ -1,5 +1,8 @@
 import type {
   Book,
+  ReplacePreview,
+  ReplacePreviewMatch,
+  ReplaceScope,
   SearchMatch,
   SearchOptions,
   Storylet,
@@ -127,6 +130,117 @@ export function searchStorylet(
   if ('error' in compiled) return []
   if (!storylet.content) return []
   return collectMatchesInContent(storylet.id, storylet.content, compiled.regex)
+}
+
+/**
+ * Expand a regex match's replacement string. Supports `$&` (whole match) and
+ * `$1`-`$9` numbered backreferences — same subset replaceAll uses. We hand-roll
+ * this so the preview's `after` snippet matches what String.replace would
+ * produce when called with the same regex+replacement.
+ */
+function expandReplacement(
+  replacement: string,
+  match: RegExpExecArray,
+): string {
+  return replacement.replace(/\$(&|\d)/g, (token, key: string) => {
+    if (key === '&') return match[0]
+    const idx = Number(key)
+    if (Number.isFinite(idx) && idx >= 1 && idx <= 9) {
+      const group = match[idx]
+      return group === undefined ? '' : group
+    }
+    return token
+  })
+}
+
+/**
+ * Build a per-match before/after preview snippet.
+ * Both snippets are drawn from the same enclosing line in the original content
+ * so they line up visually in the diff modal.
+ */
+function buildPreviewMatch(
+  content: string,
+  match: RegExpExecArray,
+  replacement: string,
+): ReplacePreviewMatch {
+  const start = match.index
+  const end = start + match[0].length
+
+  // Find enclosing line boundaries in the original content.
+  const lineStart = (() => {
+    const idx = content.lastIndexOf('\n', start - 1)
+    return idx === -1 ? 0 : idx + 1
+  })()
+  const lineEndRaw = content.indexOf('\n', end)
+  const lineEnd = lineEndRaw === -1 ? content.length : lineEndRaw
+
+  const snippetStart = Math.max(lineStart, start - SNIPPET_CONTEXT_CHARS)
+  const snippetEnd = Math.min(lineEnd, end + SNIPPET_CONTEXT_CHARS)
+
+  const beforeSnippet = content.slice(snippetStart, snippetEnd)
+  const beforeMatchRange: [number, number] = [
+    start - snippetStart,
+    end - snippetStart,
+  ]
+
+  const replacementText = expandReplacement(replacement, match)
+  const afterSnippet =
+    content.slice(snippetStart, start) +
+    replacementText +
+    content.slice(end, snippetEnd)
+  const afterReplacementRange: [number, number] = [
+    start - snippetStart,
+    start - snippetStart + replacementText.length,
+  ]
+
+  return {
+    start,
+    end,
+    beforeSnippet,
+    beforeMatchRange,
+    afterSnippet,
+    afterReplacementRange,
+  }
+}
+
+/**
+ * Compute per-storylet before/after previews for a Find+Replace operation.
+ * Honors the same scope semantics as `replaceAllInBook`. Storylets with no
+ * matches are omitted. Capped per storylet by MAX_MATCHES_PER_STORYLET.
+ */
+export function computeReplacePreview(
+  book: Book,
+  options: SearchOptions,
+  replacement: string,
+  scope: ReplaceScope,
+  targetStoryletId?: string,
+): ReplacePreview[] {
+  const compiled = compileQuery(options)
+  if ('error' in compiled) return []
+  const { regex } = compiled
+  const previews: ReplacePreview[] = []
+  for (const storylet of getStoryletTreeOrder(book)) {
+    if (scope === 'storylet' && storylet.id !== targetStoryletId) continue
+    if (!storylet.content) continue
+    const flags = regex.flags.includes('g') ? regex.flags : `${regex.flags}g`
+    const scanner = new RegExp(regex.source, flags)
+    const matches: ReplacePreviewMatch[] = []
+    let m: RegExpExecArray | null
+    while ((m = scanner.exec(storylet.content)) !== null) {
+      matches.push(buildPreviewMatch(storylet.content, m, replacement))
+      if (matches.length >= MAX_MATCHES_PER_STORYLET) break
+      if (m[0].length === 0) {
+        scanner.lastIndex = scanner.lastIndex + 1
+      }
+    }
+    if (matches.length === 0) continue
+    previews.push({
+      storyletId: storylet.id,
+      storyletName: storylet.name,
+      matches,
+    })
+  }
+  return previews
 }
 
 /**

--- a/src/lib/bookSearch.ts
+++ b/src/lib/bookSearch.ts
@@ -1,0 +1,154 @@
+import type {
+  Book,
+  SearchMatch,
+  SearchOptions,
+  Storylet,
+  StoryletSearchResult,
+} from '../types'
+import { getStoryletTreeOrder } from './characterState'
+
+/** Maximum number of matches collected per storylet to guard against pathological regexes. */
+export const MAX_MATCHES_PER_STORYLET = 500
+
+/** Approximate context window around each match when building snippets. */
+const SNIPPET_CONTEXT_CHARS = 40
+
+/** Result of compiling a user query into a regex (or the error message). */
+export type CompileQueryResult =
+  | { regex: RegExp }
+  | { error: string }
+
+/**
+ * Compile user search options into a global regex. Handles:
+ * - regex vs literal mode (literal escapes special chars)
+ * - case sensitivity (sets the `i` flag when off)
+ * - whole-word wrapping (`\b…\b`)
+ *
+ * Returns a tagged error object on compile failure (invalid regex syntax)
+ * or empty queries — callers should display the error inline.
+ */
+export function compileQuery(options: SearchOptions): CompileQueryResult {
+  const { query, caseSensitive, wholeWord, regex } = options
+  if (query.length === 0) {
+    return { error: 'Enter a search query' }
+  }
+  let pattern = regex ? query : escapeRegex(query)
+  if (wholeWord) {
+    pattern = `\\b(?:${pattern})\\b`
+  }
+  const flags = caseSensitive ? 'g' : 'gi'
+  try {
+    return { regex: new RegExp(pattern, flags) }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Invalid regular expression'
+    return { error: message }
+  }
+}
+
+/** Escape a literal string so it can be embedded safely in a RegExp source. */
+function escapeRegex(literal: string): string {
+  return literal.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+/**
+ * Collect every match in `content` for the given regex, capped at
+ * MAX_MATCHES_PER_STORYLET. Guards against zero-width matches by advancing
+ * `lastIndex` manually when a match consumes no characters.
+ */
+function collectMatchesInContent(
+  storyletId: string,
+  content: string,
+  regex: RegExp,
+): SearchMatch[] {
+  // Defensive: clone the regex so callers can reuse it across storylets without
+  // stale `lastIndex` state and to ensure the global flag is set.
+  const flags = regex.flags.includes('g') ? regex.flags : `${regex.flags}g`
+  const scanner = new RegExp(regex.source, flags)
+  const matches: SearchMatch[] = []
+  let m: RegExpExecArray | null
+  while ((m = scanner.exec(content)) !== null) {
+    const start = m.index
+    const end = start + m[0].length
+    matches.push({
+      storyletId,
+      start,
+      end,
+      ...buildSnippet(content, start, end),
+    })
+    if (matches.length >= MAX_MATCHES_PER_STORYLET) break
+    // Avoid infinite loops on zero-width matches (e.g. /\b/g).
+    if (m[0].length === 0) {
+      scanner.lastIndex = scanner.lastIndex + 1
+    }
+  }
+  return matches
+}
+
+/**
+ * Extract a human-readable snippet around a match: ~SNIPPET_CONTEXT_CHARS on
+ * each side, trimmed to the enclosing line(s) so we never bleed into unrelated
+ * lines. Returns the snippet text and the [start,end) match offset *within the
+ * snippet* so callers can highlight it without re-searching.
+ */
+function buildSnippet(
+  content: string,
+  matchStart: number,
+  matchEnd: number,
+): { lineSnippet: string; matchIndexInSnippet: [number, number] } {
+  // Find enclosing line boundaries.
+  const lineStart = (() => {
+    const idx = content.lastIndexOf('\n', matchStart - 1)
+    return idx === -1 ? 0 : idx + 1
+  })()
+  const lineEndRaw = content.indexOf('\n', matchEnd)
+  const lineEnd = lineEndRaw === -1 ? content.length : lineEndRaw
+
+  // Then clamp to ±SNIPPET_CONTEXT_CHARS, but never escape the enclosing line.
+  const snippetStart = Math.max(lineStart, matchStart - SNIPPET_CONTEXT_CHARS)
+  const snippetEnd = Math.min(lineEnd, matchEnd + SNIPPET_CONTEXT_CHARS)
+
+  const lineSnippet = content.slice(snippetStart, snippetEnd)
+  const matchIndexInSnippet: [number, number] = [
+    matchStart - snippetStart,
+    matchEnd - snippetStart,
+  ]
+  return { lineSnippet, matchIndexInSnippet }
+}
+
+/**
+ * Search a single storylet for matches. Used by phase 3's storylet-scoped
+ * replace path.
+ */
+export function searchStorylet(
+  storylet: Storylet,
+  options: SearchOptions,
+): SearchMatch[] {
+  const compiled = compileQuery(options)
+  if ('error' in compiled) return []
+  if (!storylet.content) return []
+  return collectMatchesInContent(storylet.id, storylet.content, compiled.regex)
+}
+
+/**
+ * Search every storylet in the book in tree (depth-first) order. Storylets
+ * with no matches are omitted from the result.
+ */
+export function searchBook(
+  book: Book,
+  options: SearchOptions,
+): StoryletSearchResult[] {
+  const compiled = compileQuery(options)
+  if ('error' in compiled) return []
+  const results: StoryletSearchResult[] = []
+  for (const storylet of getStoryletTreeOrder(book)) {
+    if (!storylet.content) continue
+    const matches = collectMatchesInContent(storylet.id, storylet.content, compiled.regex)
+    if (matches.length === 0) continue
+    results.push({
+      storyletId: storylet.id,
+      storyletName: storylet.name,
+      matches,
+    })
+  }
+  return results
+}

--- a/src/stores/keybindingStore.ts
+++ b/src/stores/keybindingStore.ts
@@ -12,6 +12,7 @@ export type ActionName =
   | 'toggleCharacterPanel'
   | 'insertStatMarker'
   | 'publishStorylet'
+  | 'findInBook'
 
 export interface KeyCombo {
   key: string  // e.g. 'f', 's', 'h'
@@ -34,10 +35,11 @@ export const ACTION_LABELS: Record<ActionName, string> = {
   toggleCharacterPanel: 'Toggle Character Panel',
   insertStatMarker: 'Insert stat change',
   publishStorylet: 'Toggle publish panel',
+  findInBook: 'Find in book',
 }
 
 export const DEFAULT_KEYMAP: KeyMap = {
-  toggleTypewriter: { key: 'f', ctrl: true, shift: true },
+  toggleTypewriter: { key: 'm', ctrl: true, shift: true },
   toggleFileTree: { key: 'b', ctrl: true },
   saveToDisk: { key: 's', ctrl: true },
   closeBook: { key: 'o', ctrl: true },
@@ -46,6 +48,7 @@ export const DEFAULT_KEYMAP: KeyMap = {
   toggleCharacterPanel: { key: 'c', ctrl: true, shift: true },
   insertStatMarker: { key: '.', ctrl: true, shift: true },
   publishStorylet: { key: 'p', ctrl: true, shift: true },
+  findInBook: { key: 'f', ctrl: true, shift: true },
 }
 
 export function comboToString(combo: KeyCombo): string {

--- a/src/stores/storyletStore.ts
+++ b/src/stores/storyletStore.ts
@@ -646,7 +646,12 @@ export const useStoryletStore = create<StoryletState>()(
           if (out === original) return storylet
           storyletsChanged++
           matchesReplaced += count
-          return { ...storylet, content: out, updatedAt: timestamp }
+          return {
+            ...storylet,
+            content: out,
+            updatedAt: timestamp,
+            docVersion: (storylet.docVersion ?? 0) + 1,
+          }
         })
         if (storyletsChanged === 0) {
           return { storyletsChanged: 0, matchesReplaced: 0 }

--- a/src/stores/storyletStore.ts
+++ b/src/stores/storyletStore.ts
@@ -1,7 +1,8 @@
 import { create } from 'zustand'
 import { persist, createJSONStorage } from 'zustand/middleware'
 import * as localforage from 'localforage'
-import type { Book, Storylet, DocumentStyles, GlobalSettings, NamedStyle, WritinatorFile } from '../types'
+import type { Book, Storylet, DocumentStyles, GlobalSettings, NamedStyle, ReplaceScope, SearchOptions, WritinatorFile } from '../types'
+import { compileQuery, MAX_MATCHES_PER_STORYLET } from '../lib/bookSearch'
 
 function createDefaultDocumentStyles(): DocumentStyles {
   return {
@@ -70,6 +71,12 @@ interface StoryletState {
   updateGlobalSettings: (patch: Partial<GlobalSettings>) => void
   renameStyle: (oldName: string, newName: string) => void
   replaceInlineStyleInOtherDocs: (styleString: string, className: string) => number
+  replaceAllInBook: (
+    options: SearchOptions,
+    replacement: string,
+    scope: ReplaceScope,
+    targetStoryletId?: string,
+  ) => { storyletsChanged: number; matchesReplaced: number }
 }
 
 function generateId(): string {
@@ -592,6 +599,62 @@ export const useStoryletStore = create<StoryletState>()(
         if (total === 0) return 0
         set({ book: { ...book, storylets: nextStorylets, updatedAt: now() } })
         return total
+      },
+
+      replaceAllInBook: (
+        options: SearchOptions,
+        replacement: string,
+        scope: ReplaceScope,
+        targetStoryletId?: string,
+      ) => {
+        get()._flushContentUpdate()
+        const { book } = get()
+        if (!book) return { storyletsChanged: 0, matchesReplaced: 0 }
+        const compiled = compileQuery(options)
+        if ('error' in compiled) return { storyletsChanged: 0, matchesReplaced: 0 }
+        const { regex } = compiled
+        const timestamp = now()
+        let storyletsChanged = 0
+        let matchesReplaced = 0
+        const nextStorylets = book.storylets.map((storylet) => {
+          if (scope === 'storylet' && storylet.id !== targetStoryletId) return storylet
+          if (!storylet.content) return storylet
+          // Build a fresh scanner so we don't mutate `regex.lastIndex` across storylets,
+          // and so we can cap the number of replacements per storylet.
+          const flags = regex.flags.includes('g') ? regex.flags : `${regex.flags}g`
+          const scanner = new RegExp(regex.source, flags)
+          const original = storylet.content
+          let cursor = 0
+          let count = 0
+          let out = ''
+          let m: RegExpExecArray | null
+          while ((m = scanner.exec(original)) !== null) {
+            const start = m.index
+            const end = start + m[0].length
+            out += original.slice(cursor, start)
+            out += replacement
+            cursor = end
+            count++
+            if (count >= MAX_MATCHES_PER_STORYLET) break
+            // Avoid infinite loops on zero-width matches.
+            if (m[0].length === 0) {
+              scanner.lastIndex = scanner.lastIndex + 1
+            }
+          }
+          if (count === 0) return storylet
+          out += original.slice(cursor)
+          if (out === original) return storylet
+          storyletsChanged++
+          matchesReplaced += count
+          return { ...storylet, content: out, updatedAt: timestamp }
+        })
+        if (storyletsChanged === 0) {
+          return { storyletsChanged: 0, matchesReplaced: 0 }
+        }
+        set({
+          book: { ...book, storylets: nextStorylets, updatedAt: timestamp },
+        })
+        return { storyletsChanged, matchesReplaced }
       },
 
       _flushContentUpdate: () => {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -9,6 +9,13 @@ export interface Storylet {
   updatedAt: string
   lastPublishedAt?: string
   lastPublishedSnapshotId?: string
+  /**
+   * Bumped on external bulk mutations (e.g. Find-in-Book replace) so the
+   * editor view can reload the document even when the active storylet id
+   * hasn't changed. Defaults to 0 for storylets persisted before this field
+   * was introduced.
+   */
+  docVersion?: number
 }
 
 export interface PublishedSnapshot {
@@ -106,6 +113,26 @@ export interface StoryletSearchResult {
 }
 
 export type ReplaceScope = 'storylet' | 'book'
+
+/**
+ * A single match's before/after snippet used by the replace preview modal.
+ * `before` is the existing line snippet (with match offsets); `after` is what
+ * the snippet will look like once the replacement is applied.
+ */
+export interface ReplacePreviewMatch {
+  start: number
+  end: number
+  beforeSnippet: string
+  beforeMatchRange: [number, number]
+  afterSnippet: string
+  afterReplacementRange: [number, number]
+}
+
+export interface ReplacePreview {
+  storyletId: string
+  storyletName: string
+  matches: ReplacePreviewMatch[]
+}
 
 export interface TextStyle {
   fontFamily?: string        // CSS font-family value

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -77,8 +77,35 @@ export interface Snapshot {
   content: string
   wordCount: number
   timestamp: string
-  trigger: 'manual' | 'switch' | 'auto' | 'closeBook'
+  trigger: 'manual' | 'switch' | 'auto' | 'closeBook' | 'bulkReplace'
 }
+
+// ---------------------------------------------------------------------------
+// Find in Book — Phase 1: search types
+// ---------------------------------------------------------------------------
+
+export interface SearchOptions {
+  query: string
+  caseSensitive: boolean
+  wholeWord: boolean
+  regex: boolean
+}
+
+export interface SearchMatch {
+  storyletId: string
+  start: number
+  end: number
+  lineSnippet: string
+  matchIndexInSnippet: [number, number]
+}
+
+export interface StoryletSearchResult {
+  storyletId: string
+  storyletName: string
+  matches: SearchMatch[]
+}
+
+export type ReplaceScope = 'storylet' | 'book'
 
 export interface TextStyle {
   fontFamily?: string        // CSS font-family value


### PR DESCRIPTION
- ReplacePreview / ReplacePreviewMatch types + computeReplacePreview()
  build per-storylet, per-match before/after snippets aligned to the same
  line-clamped windows as searchBook().
- Storylet.docVersion?: number bumped by replaceAllInBook on changed
  storylets. Optional/undefined-tolerant so books persisted before this
  phase migrate as 0 with no schema bump.
- Editor's loadedDocumentRef widened to {id, version}; load-effect now
  reloads when either changes, preserving the same-id-same-version fast
  path so normal typing never re-dispatches.
- ReplacePreviewModal: centered overlay (z-[60], mirrors PublishModal),
  per-storylet sections, per-match red-strike/green diffs with -/+
  gutters, Cancel + Replace & snapshot footer.
- FindInBook grew: replace input, This storylet | Whole book segmented
  control, Replace button → preview modal, on confirm
  snapshotBook(book, 'bulkReplace') → replaceAllInBook(...) → inline
  "Replaced X matches in Y storylets. Snapshot saved." with
  "Open History to revert" hint. Click-outside-to-close suppressed
  while the modal is open.