### PR TITLE
Worktree-notes-feature

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.4.0",
         "jsdom": "^29.0.1",
-        "puppeteer": "^24.40.0",
+        "puppeteer": "^24.41.0",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.57.0",
         "vite": "^8.0.1"
@@ -2337,9 +2337,9 @@
       }
     },
     "node_modules/bare-fs": {
-      "version": "4.5.6",
-      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.5.6.tgz",
-      "integrity": "sha512-1QovqDrR80Pmt5HPAsMsXTCFcDYr+NSUKW6nd6WO5v0JBmnItc/irNRzm2KOQ5oZ69P37y+AMujNyNtG+1Rggw==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.1.tgz",
+      "integrity": "sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2362,9 +2362,9 @@
       }
     },
     "node_modules/bare-os": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.8.0.tgz",
-      "integrity": "sha512-Dc9/SlwfxkXIGYhvMQNUtKaXCaGkZYGcd1vuNUUADVqzu4/vQfvnMkYYOUnt2VwQ2AqKr/8qAVFRtwETljgeFg==",
+      "version": "3.8.7",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.8.7.tgz",
+      "integrity": "sha512-G4Gr1UsGeEy2qtDTZwL7JFLo2wapUarz7iTMcYcMFdS89AIQuBoyjgXZz0Utv7uHs3xA9LckhVbeBi8lEQrC+w==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -2382,9 +2382,9 @@
       }
     },
     "node_modules/bare-stream": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.11.0.tgz",
-      "integrity": "sha512-Y/+iQ49fL3rIn6w/AVxI/2+BRrpmzJvdWt5Jv8Za6Ngqc6V227c+pYjYYgLdpR3MwQ9ObVXD0ZrqoBztakM0rw==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.0.tgz",
+      "integrity": "sha512-3zAJRZMDFGjdn+RVnNpF9kuELw+0Fl3lpndM4NcEOhb9zwtSo/deETfuIwMSE5BXanA0FrN1qVjffGwAg2Y7EA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2409,9 +2409,9 @@
       }
     },
     "node_modules/bare-url": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.0.tgz",
-      "integrity": "sha512-NSTU5WN+fy/L0DDenfE8SXQna4voXuW0FHM7wH8i3/q9khUSchfPbPezO4zSFMnDGIf9YE+mt/RWhZgNRKRIXA==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.1.tgz",
+      "integrity": "sha512-fZapLWNB25gS+etK27NV9KgBNXgo2yeYHuj+OyPblQd6GYAE3JVy6aKxszMV5jhGGFwraXQKA5fldvf3lMyEqw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2441,9 +2441,9 @@
       }
     },
     "node_modules/basic-ftp": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.0.tgz",
-      "integrity": "sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.0.tgz",
+      "integrity": "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2930,9 +2930,9 @@
       }
     },
     "node_modules/devtools-protocol": {
-      "version": "0.0.1581282",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1581282.tgz",
-      "integrity": "sha512-nv7iKtNZQshSW2hKzYNr46nM/Cfh5SEvE2oV0/SEGgc9XupIY5ggf84Cz8eJIkBce7S3bmTAauFD6aysMpnqsQ==",
+      "version": "0.0.1595872",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1595872.tgz",
+      "integrity": "sha512-kRfgp8vWVjBu/fbYCiVFiOqsCk3CrMKEo3WbgGT2NXK2dG7vawWPBljixajVgGK9II8rDO9G0oD0zLt3I1daRg==",
       "dev": true,
       "license": "BSD-3-Clause",
       "peer": true
@@ -5214,9 +5214,9 @@
       "license": "MIT"
     },
     "node_modules/netmask": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
-      "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.1.1.tgz",
+      "integrity": "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5577,9 +5577,9 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "24.40.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-24.40.0.tgz",
-      "integrity": "sha512-IxQbDq93XHVVLWHrAkFP7F7iHvb9o0mgfsSIMlhHb+JM+JjM1V4v4MNSQfcRWJopx9dsNOr9adYv0U5fm9BJBQ==",
+      "version": "24.41.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-24.41.0.tgz",
+      "integrity": "sha512-W6Fk0J3TPjjtwjXOyR/qf+YaL0H/Uq8HIgHcXG4mNM/IgbKMCH/HPyK0Fi2qbTU/QpSl9bCte2yBpGHKejTpIw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -5587,8 +5587,8 @@
         "@puppeteer/browsers": "2.13.0",
         "chromium-bidi": "14.0.0",
         "cosmiconfig": "^9.0.0",
-        "devtools-protocol": "0.0.1581282",
-        "puppeteer-core": "24.40.0",
+        "devtools-protocol": "0.0.1595872",
+        "puppeteer-core": "24.41.0",
         "typed-query-selector": "^2.12.1"
       },
       "bin": {
@@ -5599,16 +5599,16 @@
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "24.40.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.40.0.tgz",
-      "integrity": "sha512-MWL3XbUCfVgGR0gRsidzT6oKJT2QydPLhMITU6HoVWiiv4gkb6gJi3pcdAa8q4HwjBTbqISOWVP4aJiiyUJvag==",
+      "version": "24.41.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.41.0.tgz",
+      "integrity": "sha512-rLIUri7E/NQ3APSEYCCozaSJx0u8Tu9wxO6BJwnvXmIgILSK3L0TombaVh3izp1njAGrO6H2ru0hcIrLF+gWLw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@puppeteer/browsers": "2.13.0",
         "chromium-bidi": "14.0.0",
         "debug": "^4.4.3",
-        "devtools-protocol": "0.0.1581282",
+        "devtools-protocol": "0.0.1595872",
         "typed-query-selector": "^2.12.1",
         "webdriver-bidi-protocol": "0.4.1",
         "ws": "^8.19.0"

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.4.0",
     "jsdom": "^29.0.1",
-    "puppeteer": "^24.40.0",
+    "puppeteer": "^24.41.0",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.57.0",
     "vite": "^8.0.1"

--- a/src/components/characters/CharacterPanel.tsx
+++ b/src/components/characters/CharacterPanel.tsx
@@ -24,6 +24,8 @@ interface Props {
   onClose: () => void
   editorView: EditorView | null
   onOpenCharacterSheet?: () => void
+  /** When true, render only the inner body (tabs + content) — skip outer wrapper and header. */
+  embedded?: boolean
 }
 
 function formatModifier(mod: StatModifier, defs: StatDefinition[]): string {
@@ -364,7 +366,7 @@ function CharacterSection({ character, computed }: SectionProps) {
   )
 }
 
-export function CharacterPanel({ open, onClose, onOpenCharacterSheet, editorView }: Props) {
+export function CharacterPanel({ open, onClose, onOpenCharacterSheet, editorView, embedded = false }: Props) {
   const characters = useCharacterStore((s) => s.characters)
   const markers = useCharacterStore((s) => s.markers)
   const removeMarkerFromStore = useCharacterStore((s) => s.removeMarker)
@@ -422,22 +424,8 @@ export function CharacterPanel({ open, onClose, onOpenCharacterSheet, editorView
 
   if (!open) return null
 
-  return (
-    <div
-      data-testid="character-panel"
-      className="flex flex-col bg-gray-900 border-l border-gray-700 h-full w-[320px] shrink-0 overflow-hidden"
-    >
-      {/* Header */}
-      <div className="flex items-center justify-between px-4 py-3 border-b border-gray-700">
-        <span className="text-sm font-medium text-gray-200">Characters</span>
-        <button
-          onClick={onClose}
-          className="text-gray-500 hover:text-gray-300 text-xs"
-        >
-          Close
-        </button>
-      </div>
-
+  const body = (
+    <>
       {/* Tabs */}
       <div className="flex border-b border-gray-700 bg-gray-900/60">
         <TabButton active={tab === 'stats'} onClick={() => setTab('stats')} testId="character-panel-tab-stats">
@@ -569,6 +557,33 @@ export function CharacterPanel({ open, onClose, onOpenCharacterSheet, editorView
           />
         )}
       </div>
+    </>
+  )
+
+  if (embedded) {
+    return (
+      <div data-testid="character-panel" className="flex flex-col h-full overflow-hidden">
+        {body}
+      </div>
+    )
+  }
+
+  return (
+    <div
+      data-testid="character-panel"
+      className="flex flex-col bg-gray-900 border-l border-gray-700 h-full w-[320px] shrink-0 overflow-hidden"
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 py-3 border-b border-gray-700">
+        <span className="text-sm font-medium text-gray-200">Characters</span>
+        <button
+          onClick={onClose}
+          className="text-gray-500 hover:text-gray-300 text-xs"
+        >
+          Close
+        </button>
+      </div>
+      {body}
     </div>
   )
 }

--- a/src/components/editor/BubbleToolbar.tsx
+++ b/src/components/editor/BubbleToolbar.tsx
@@ -9,6 +9,7 @@ import { DEFAULT_STYLE_NAMES } from '../../types'
 interface BubbleToolbarProps {
   editorView: EditorView | null
   onInsertMarker?: (markerId: string) => void
+  onInsertNote?: () => void
   onEditStyles?: () => void
 }
 
@@ -842,7 +843,7 @@ function wrapWithSpanClass(view: EditorView, className: string) {
   view.focus()
 }
 
-export default function BubbleToolbar({ editorView, onInsertMarker, onEditStyles }: BubbleToolbarProps) {
+export default function BubbleToolbar({ editorView, onInsertMarker, onInsertNote, onEditStyles }: BubbleToolbarProps) {
   const documentStyles = useStoryletStore((s) => s.globalSettings.documentStyles)
   const updateGlobalSettings = useStoryletStore((s) => s.updateGlobalSettings)
   const replaceInlineStyleInOtherDocs = useStoryletStore((s) => s.replaceInlineStyleInOtherDocs)
@@ -1132,6 +1133,19 @@ export default function BubbleToolbar({ editorView, onInsertMarker, onEditStyles
           >
             Status Block
           </button>
+          {onInsertNote && (
+            <button
+              data-testid="bubble-note-insert"
+              onMouseDown={(e) => {
+                e.preventDefault()
+                onInsertNote()
+              }}
+              title="Insert note anchor at cursor"
+              className="rounded px-2 py-1 text-xs font-medium transition-colors text-gray-300 hover:bg-gray-700 hover:text-gray-100"
+            >
+              Note
+            </button>
+          )}
         </>
       )}
 

--- a/src/components/editor/Editor.tsx
+++ b/src/components/editor/Editor.tsx
@@ -25,6 +25,10 @@ import {
   statblockMarkerExtension,
   dispatchStatblockActiveStorylet,
 } from './statblockMarkerExtension'
+import {
+  noteMarkerExtension,
+  dispatchNotesSnapshot,
+} from './noteMarkerExtension'
 import type { DocumentStyles } from '../../types'
 import type { VimMode } from './VimStatusLine'
 import './editor.css'
@@ -768,6 +772,7 @@ export default function Editor({ onWordCountChange, onVimModeChange, onEditorVie
         renderModeField,
         markdownDecorationPlugin,
         statMarkerExtension(),
+        noteMarkerExtension(),
         statblockMarkerExtension(),
         placeholder('Start writing...'),
         fontComp.of(makeFontTheme(useEditorStore.getState().fontFamily)),
@@ -1053,6 +1058,23 @@ export default function Editor({ onWordCountChange, onVimModeChange, onEditorVie
         }
       })
     }
+    return unsubscribe
+  }, [])
+
+  // Sync notes store → CM6 snapshot so note-marker squares refresh on store
+  // changes. Dispatches once on mount + any time `positionNotes` reference-
+  // changes in the Zustand store. Mirrors the character snapshot pattern.
+  useEffect(() => {
+    const view = viewRef.current
+    if (!view) return
+    const initial = useNotesStore.getState()
+    dispatchNotesSnapshot(view, { positionNotes: initial.positionNotes })
+    const unsubscribe = useNotesStore.subscribe((state, prev) => {
+      if (state.positionNotes === prev.positionNotes) return
+      const v = viewRef.current
+      if (!v) return
+      dispatchNotesSnapshot(v, { positionNotes: state.positionNotes })
+    })
     return unsubscribe
   }, [])
 

--- a/src/components/editor/Editor.tsx
+++ b/src/components/editor/Editor.tsx
@@ -15,6 +15,7 @@ import { useStoryletStore } from '../../stores/storyletStore'
 import { useEditorStore } from '../../stores/editorStore'
 import { useMetricsStore } from '../../stores/metricsStore'
 import { useCharacterStore } from '../../stores/characterStore'
+import { useNotesStore } from '../../stores/notesStore'
 import { htmlToMarkdownWithStyles } from '../../lib/richPaste'
 import {
   statMarkerExtension,
@@ -1018,6 +1019,8 @@ export default function Editor({ onWordCountChange, onVimModeChange, onEditorVie
         useCharacterStore
       ;(window as unknown as { __storyletStore?: typeof useStoryletStore }).__storyletStore =
         useStoryletStore
+      ;(window as unknown as { __notesStore?: typeof useNotesStore }).__notesStore =
+        useNotesStore
       // Expose an in-memory markdown renderer so QA can inspect export output
       // without triggering a file download.
       import('../../lib/export').then((mod) => {

--- a/src/components/editor/Editor.tsx
+++ b/src/components/editor/Editor.tsx
@@ -1037,21 +1037,31 @@ export default function Editor({ onWordCountChange, onVimModeChange, onEditorVie
             ok: boolean
             markerCount: number
             statblockCount: number
+            noteCount: number
             length: number
             preview: string
           }
         }).__exportSmokeTest = () => {
           const book = useStoryletStore.getState().book
           if (!book) {
-            return { ok: false, markerCount: 0, statblockCount: 0, length: 0, preview: '(no book)' }
+            return {
+              ok: false,
+              markerCount: 0,
+              statblockCount: 0,
+              noteCount: 0,
+              length: 0,
+              preview: '(no book)',
+            }
           }
           const out = mod.renderBookAsMarkdown(book)
           const markerCount = (out.match(/<!--\s*stat:/g) ?? []).length
           const statblockCount = (out.match(/<!--\s*statblock:/g) ?? []).length
+          const noteCount = (out.match(/<!--\s*note:/g) ?? []).length
           return {
-            ok: markerCount === 0,
+            ok: markerCount === 0 && noteCount === 0,
             markerCount,
             statblockCount,
+            noteCount,
             length: out.length,
             preview: out.slice(0, 400),
           }

--- a/src/components/editor/editor.css
+++ b/src/components/editor/editor.css
@@ -130,6 +130,28 @@
   outline-offset: 2px;
 }
 
+/* Note-marker square widget (rendered in place of `<!-- note:uuid -->`) */
+.cm-note-marker-square {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 2px;
+  vertical-align: middle;
+  margin: 0 2px;
+  cursor: pointer;
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.35) inset;
+}
+
+.cm-note-marker-square:hover {
+  outline: 2px solid rgba(255, 255, 255, 0.35);
+  outline-offset: 1px;
+}
+
+.cm-note-marker-square:focus-visible {
+  outline: 2px solid #fff;
+  outline-offset: 2px;
+}
+
 /* Typewriter mode */
 .typewriter-mode .cm-scroller {
   /* Padding to allow cursor to center when near top/bottom of document */

--- a/src/components/editor/noteMarkerExtension.ts
+++ b/src/components/editor/noteMarkerExtension.ts
@@ -1,0 +1,202 @@
+import {
+  Decoration,
+  type DecorationSet,
+  EditorView,
+  ViewPlugin,
+  type ViewUpdate,
+  WidgetType,
+} from '@codemirror/view'
+import {
+  StateEffect,
+  StateField,
+  RangeSetBuilder,
+  type Extension,
+} from '@codemirror/state'
+import type { PositionNote } from '../../types'
+import { NOTE_MARKER_REGEX } from '../../lib/noteUtils'
+
+/**
+ * Compact snapshot of notes-store state needed to render square widgets.
+ * Mirrors only what the CodeMirror plugin actually reads, so React concerns
+ * (subscriptions, selectors) stay in the wiring layer.
+ */
+export interface NotesSnapshot {
+  positionNotes: Record<string, PositionNote>
+}
+
+const EMPTY_SNAPSHOT: NotesSnapshot = { positionNotes: {} }
+
+/** StateEffect delivering a fresh snapshot into the editor state. */
+export const setNotesSnapshotEffect = StateEffect.define<NotesSnapshot>()
+
+/** Holds the latest NotesSnapshot — used by the decoration plugin. */
+const notesSnapshotField = StateField.define<NotesSnapshot>({
+  create: () => EMPTY_SNAPSHOT,
+  update(value, tr) {
+    for (const e of tr.effects) {
+      if (e.is(setNotesSnapshotEffect)) return e.value
+    }
+    return value
+  },
+})
+
+/** Dispatch a new snapshot into the view. */
+export function dispatchNotesSnapshot(
+  view: EditorView,
+  snapshot: NotesSnapshot
+): void {
+  view.dispatch({ effects: setNotesSnapshotEffect.of(snapshot) })
+}
+
+const EMPTY_NOTE_FALLBACK = 'New note'
+const TOOLTIP_PREVIEW_LEN = 60
+const NEUTRAL_COLOR = '#6b7280' // gray-500
+
+/**
+ * First-60-chars preview of a note body, collapsing whitespace. Used as the
+ * native `title=` tooltip on the square widget. Empty bodies fall back to
+ * a helpful "New note" placeholder so freshly-inserted anchors still hint
+ * at meaning on hover.
+ */
+function buildNoteTooltip(note: PositionNote | undefined): string {
+  const body = note?.body?.trim() ?? ''
+  if (!body) return EMPTY_NOTE_FALLBACK
+  const collapsed = body.replace(/\s+/g, ' ')
+  if (collapsed.length <= TOOLTIP_PREVIEW_LEN) return collapsed
+  return collapsed.slice(0, TOOLTIP_PREVIEW_LEN) + '…'
+}
+
+class NoteMarkerWidget extends WidgetType {
+  readonly noteId: string
+  readonly color: string
+  readonly tooltip: string
+  readonly ariaLabel: string
+
+  constructor(
+    noteId: string,
+    color: string,
+    tooltip: string,
+    ariaLabel: string
+  ) {
+    super()
+    this.noteId = noteId
+    this.color = color
+    this.tooltip = tooltip
+    this.ariaLabel = ariaLabel
+  }
+
+  eq(other: WidgetType): boolean {
+    if (!(other instanceof NoteMarkerWidget)) return false
+    return (
+      other.noteId === this.noteId &&
+      other.color === this.color &&
+      other.tooltip === this.tooltip &&
+      other.ariaLabel === this.ariaLabel
+    )
+  }
+
+  toDOM(): HTMLElement {
+    const span = document.createElement('span')
+    span.className = 'cm-note-marker-square'
+    span.style.backgroundColor = this.color
+    span.setAttribute('data-note-id', this.noteId)
+    span.setAttribute('title', this.tooltip)
+    span.setAttribute('role', 'button')
+    span.setAttribute('aria-label', this.ariaLabel)
+    span.tabIndex = 0
+    return span
+  }
+
+  ignoreEvent(): boolean {
+    // Let clicks/keypresses bubble so a delegated listener (Phase 7) can
+    // pick them up from contentDOM.
+    return false
+  }
+}
+
+function buildDecorations(view: EditorView): DecorationSet {
+  const snapshot = view.state.field(notesSnapshotField)
+
+  const builder = new RangeSetBuilder<Decoration>()
+  // visibleRanges are non-overlapping and increasing; iterate in order so the
+  // RangeSetBuilder invariant (monotonic from) is preserved.
+  for (const { from, to } of view.visibleRanges) {
+    const text = view.state.doc.sliceString(from, to)
+    // Fresh regex per range keeps lastIndex local.
+    const re = new RegExp(NOTE_MARKER_REGEX.source, 'g')
+    let m: RegExpExecArray | null
+    while ((m = re.exec(text)) !== null) {
+      const start = from + m.index
+      const end = start + m[0].length
+      const noteId = m[1]
+      const note = snapshot.positionNotes[noteId]
+      const color = note?.color ?? NEUTRAL_COLOR
+      const tooltip = buildNoteTooltip(note)
+      const ariaLabel = `Note — ${tooltip}`
+      builder.add(
+        start,
+        end,
+        Decoration.replace({
+          widget: new NoteMarkerWidget(noteId, color, tooltip, ariaLabel),
+        })
+      )
+    }
+  }
+  return builder.finish()
+}
+
+const noteMarkerViewPlugin = ViewPlugin.fromClass(
+  class {
+    decorations: DecorationSet
+    constructor(view: EditorView) {
+      this.decorations = buildDecorations(view)
+    }
+    update(update: ViewUpdate): void {
+      const snapshotChanged =
+        update.startState.field(notesSnapshotField) !==
+        update.state.field(notesSnapshotField)
+      if (
+        update.docChanged ||
+        update.viewportChanged ||
+        snapshotChanged
+      ) {
+        this.decorations = buildDecorations(update.view)
+      }
+    }
+  },
+  {
+    decorations: (v) => v.decorations,
+    // Widgets replace an entire comment range; atomicRanges keeps cursor
+    // motion across the square feel natural (jump over the whole widget).
+    provide: (plugin) =>
+      EditorView.atomicRanges.of((view) => {
+        return view.plugin(plugin)?.decorations ?? Decoration.none
+      }),
+  }
+)
+
+const noteMarkerBaseTheme = EditorView.baseTheme({
+  '.cm-note-marker-square': {
+    display: 'inline-block',
+    width: '8px',
+    height: '8px',
+    borderRadius: '2px',
+    verticalAlign: 'middle',
+    margin: '0 2px',
+    cursor: 'pointer',
+    boxShadow: '0 0 0 1px rgba(0,0,0,0.35) inset',
+  },
+  '.cm-note-marker-square:hover': {
+    outline: '2px solid rgba(255,255,255,0.35)',
+    outlineOffset: '1px',
+  },
+  '.cm-note-marker-square:focus-visible': {
+    outline: '2px solid #fff',
+    outlineOffset: '2px',
+  },
+})
+
+/** Bundle of the StateField, ViewPlugin, and base theme. */
+export function noteMarkerExtension(): Extension {
+  return [notesSnapshotField, noteMarkerViewPlugin, noteMarkerBaseTheme]
+}

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -25,6 +25,7 @@ import { CharacterSheetModal } from '../characters/CharacterSheetModal'
 import { CharacterPanel } from '../characters/CharacterPanel'
 import { DeltaEditorModal } from '../characters/DeltaEditorModal'
 import { NotesPanel } from '../notes/NotesPanel'
+import { NoteEditorModal } from '../notes/NoteEditorModal'
 import { useImageRevealStore } from '../../stores/imageRevealStore'
 import { usePublishSyncStore } from '../../stores/publishSyncStore'
 import { getPublishedSnapshots } from '../../stores/publishedSnapshotStore'
@@ -59,6 +60,12 @@ export function AppShell() {
   const [characterSheetOpen, setCharacterSheetOpen] = useState(false)
   const [characterPanelOpen, setCharacterPanelOpen] = useState(false)
   const [notesPanelOpen, setNotesPanelOpen] = useState(false)
+  const [focusedNoteId, setFocusedNoteId] = useState<string | null>(null)
+  const [noteEditorState, setNoteEditorState] = useState<{
+    open: boolean
+    noteId: string | null
+    mode: 'create' | 'edit'
+  }>({ open: false, noteId: null, mode: 'create' })
   const [deltaEditorState, setDeltaEditorState] = useState<{
     open: boolean
     markerId: string | null
@@ -159,6 +166,27 @@ export function AppShell() {
     return () => contentDOM.removeEventListener('click', onClick)
   }, [editorView])
 
+  // Delegated click listener for note squares — opens the panel + focuses the row.
+  // Does NOT open the editor modal (the row's Edit button does that).
+  useEffect(() => {
+    if (!editorView) return
+    const contentDOM = editorView.contentDOM
+    function onClick(e: MouseEvent) {
+      const target = e.target as HTMLElement | null
+      if (!target) return
+      const square = target.closest('[data-note-id]') as HTMLElement | null
+      if (!square) return
+      const noteId = square.getAttribute('data-note-id')
+      if (!noteId) return
+      e.preventDefault()
+      e.stopPropagation()
+      setNotesPanelOpen(true)
+      setFocusedNoteId(noteId)
+    }
+    contentDOM.addEventListener('click', onClick)
+    return () => contentDOM.removeEventListener('click', onClick)
+  }, [editorView])
+
   const handleRestoreSnapshot = useCallback((content: string) => {
     if (!editorView) return
     editorView.dispatch({
@@ -187,7 +215,18 @@ export function AppShell() {
       changes: { from: to, to, insert: `<!-- note:${noteId} -->` },
     })
     useNotesStore.getState().addPositionNote(noteId, { body: '' })
+    setNoteEditorState({ open: true, noteId, mode: 'create' })
   }, [])
+
+  const openNoteEditor = useCallback((noteId: string) => {
+    setNoteEditorState({ open: true, noteId, mode: 'edit' })
+  }, [])
+
+  const closeNoteEditor = useCallback(() => {
+    setNoteEditorState((prev) => ({ ...prev, open: false }))
+  }, [])
+
+  const clearFocusedNote = useCallback(() => setFocusedNoteId(null), [])
 
   const handleSaveToDisk = useCallback(() => {
     const state = useStoryletStore.getState()
@@ -625,8 +664,20 @@ export function AppShell() {
           <NotesPanel
             open={notesPanelOpen}
             onClose={() => setNotesPanelOpen(false)}
+            editorView={editorView}
+            focusedNoteId={focusedNoteId}
+            onFocusHandled={clearFocusedNote}
+            onEditNote={openNoteEditor}
           />
         )}
+
+        <NoteEditorModal
+          open={noteEditorState.open}
+          onClose={closeNoteEditor}
+          noteId={noteEditorState.noteId}
+          mode={noteEditorState.mode}
+          editorView={editorView}
+        />
       </div>
 
       {!distractionFree && <ImageRevealPanel />}

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -36,6 +36,7 @@ import { usePlayerStore } from '../../stores/playerStore'
 import { useWriteathonStore } from '../../stores/writeathonStore'
 import { countWords, extractWords } from '../../lib/words'
 import { useMetricsStore } from '../../stores/metricsStore'
+import { useNotesStore } from '../../stores/notesStore'
 import { JourneyBar } from './JourneyBar'
 import { DailyTarget } from './DailyTarget'
 import { MilestoneFlash } from './MilestoneFlash'
@@ -175,6 +176,17 @@ export function AppShell() {
     setDeltaEditorState({ open: true, markerId, mode: 'create' })
   }, [])
 
+  const handleInsertNote = useCallback(() => {
+    const view = editorViewRef.current
+    if (!view) return
+    const { to } = view.state.selection.main
+    const noteId = crypto.randomUUID()
+    view.dispatch({
+      changes: { from: to, to, insert: `<!-- note:${noteId} -->` },
+    })
+    useNotesStore.getState().addPositionNote(noteId, { body: '' })
+  }, [])
+
   const handleSaveToDisk = useCallback(() => {
     const state = useStoryletStore.getState()
     state._flushContentUpdate()
@@ -247,10 +259,16 @@ export function AppShell() {
         handleInsertStatMarker()
         return
       }
+      if (km.insertNote && matchesEvent(km.insertNote, e)) {
+        if (!editorViewRef.current) return
+        e.preventDefault()
+        handleInsertNote()
+        return
+      }
     }
     document.addEventListener('keydown', handleKeyDown)
     return () => document.removeEventListener('keydown', handleKeyDown)
-  }, [toggleDistractionFree, toggleRenderMode, handleSaveToDisk, handleInsertStatMarker])
+  }, [toggleDistractionFree, toggleRenderMode, handleSaveToDisk, handleInsertStatMarker, handleInsertNote])
 
   // Auto-snapshot every 5 minutes
   useEffect(() => {
@@ -521,6 +539,7 @@ export function AppShell() {
           <BubbleToolbar
             editorView={editorView}
             onInsertMarker={handleInsertMarker}
+            onInsertNote={handleInsertNote}
             onEditStyles={() => setStyleEditorOpen(true)}
           />
           <FindInBook

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -26,6 +26,7 @@ import { CharacterPanel } from '../characters/CharacterPanel'
 import { DeltaEditorModal } from '../characters/DeltaEditorModal'
 import { NotesPanel } from '../notes/NotesPanel'
 import { NoteEditorModal } from '../notes/NoteEditorModal'
+import { RightPanelShell, type RightPanel } from './RightPanelShell'
 import { useImageRevealStore } from '../../stores/imageRevealStore'
 import { usePublishSyncStore } from '../../stores/publishSyncStore'
 import { getPublishedSnapshots } from '../../stores/publishedSnapshotStore'
@@ -228,6 +229,32 @@ export function AppShell() {
 
   const clearFocusedNote = useCallback(() => setFocusedNoteId(null), [])
 
+  // Toggle a right-panel flag; when opening (false → true), make it the
+  // active tab in the shell so the user sees what they just opened. When
+  // closing, leave the persisted active tab alone — the shell falls back to
+  // another open panel automatically.
+  const toggleCharacterPanel = useCallback(() => {
+    setCharacterPanelOpen((prev) => {
+      const next = !prev
+      if (next) useEditorStore.getState().setRightPanelActiveTab('characters')
+      return next
+    })
+  }, [])
+  const toggleNotesPanel = useCallback(() => {
+    setNotesPanelOpen((prev) => {
+      const next = !prev
+      if (next) useEditorStore.getState().setRightPanelActiveTab('notes')
+      return next
+    })
+  }, [])
+  const togglePublishedSnapshots = useCallback(() => {
+    setPublishedSnapshotsOpen((prev) => {
+      const next = !prev
+      if (next) useEditorStore.getState().setRightPanelActiveTab('history')
+      return next
+    })
+  }, [])
+
   const handleSaveToDisk = useCallback(() => {
     const state = useStoryletStore.getState()
     state._flushContentUpdate()
@@ -261,7 +288,7 @@ export function AppShell() {
       }
       if (km.snapshotHistory && matchesEvent(km.snapshotHistory, e)) {
         e.preventDefault()
-        setPublishedSnapshotsOpen((prev) => !prev)
+        togglePublishedSnapshots()
         return
       }
       if (km.exportBook && matchesEvent(km.exportBook, e)) {
@@ -291,12 +318,12 @@ export function AppShell() {
       }
       if (km.toggleCharacterPanel && matchesEvent(km.toggleCharacterPanel, e)) {
         e.preventDefault()
-        setCharacterPanelOpen((p) => !p)
+        toggleCharacterPanel()
         return
       }
       if (km.toggleNotesPanel && matchesEvent(km.toggleNotesPanel, e)) {
         e.preventDefault()
-        setNotesPanelOpen((p) => !p)
+        toggleNotesPanel()
         return
       }
       if (km.insertStatMarker && matchesEvent(km.insertStatMarker, e)) {
@@ -314,7 +341,16 @@ export function AppShell() {
     }
     document.addEventListener('keydown', handleKeyDown)
     return () => document.removeEventListener('keydown', handleKeyDown)
-  }, [toggleDistractionFree, toggleRenderMode, handleSaveToDisk, handleInsertStatMarker, handleInsertNote])
+  }, [
+    toggleDistractionFree,
+    toggleRenderMode,
+    handleSaveToDisk,
+    handleInsertStatMarker,
+    handleInsertNote,
+    toggleCharacterPanel,
+    toggleNotesPanel,
+    togglePublishedSnapshots,
+  ])
 
   // Auto-snapshot every 5 minutes
   useEffect(() => {
@@ -460,9 +496,9 @@ export function AppShell() {
     { action: 'toggleRenderMode', label: 'Cycle presentation', onSelect: toggleRenderMode },
     { action: 'toggleFileTree', label: 'Toggle file tree', onSelect: () => useEditorStore.getState().toggleSidebar() },
     { action: 'findInBook', label: 'Find in book', onSelect: () => setFindOpen((prev) => !prev) },
-    { action: 'snapshotHistory', label: 'History', onSelect: () => setPublishedSnapshotsOpen((prev) => !prev) },
-    { action: 'toggleCharacterPanel', label: 'Character stats', onSelect: () => setCharacterPanelOpen((p) => !p) },
-    { action: 'toggleNotesPanel', label: 'Notes', onSelect: () => setNotesPanelOpen((p) => !p) },
+    { action: 'snapshotHistory', label: 'History', onSelect: togglePublishedSnapshots },
+    { action: 'toggleCharacterPanel', label: 'Character stats', onSelect: toggleCharacterPanel },
+    { action: 'toggleNotesPanel', label: 'Notes', onSelect: toggleNotesPanel },
     { action: 'insertStatMarker', label: 'Insert stat change', onSelect: handleInsertStatMarker },
     { action: 'closeBook', label: 'Open new book', onSelect: () => { void useStoryletStore.getState().closeBook() } },
   ]
@@ -549,7 +585,7 @@ export function AppShell() {
             </button>
             <button
               data-testid="character-panel-button"
-              onClick={() => setCharacterPanelOpen((p) => !p)}
+              onClick={toggleCharacterPanel}
               className="text-gray-500 hover:text-gray-300 transition-colors px-2 py-0.5 text-xs"
               title="Character stats panel (Ctrl+Shift+C)"
             >
@@ -557,14 +593,14 @@ export function AppShell() {
             </button>
             <button
               data-testid="notes-panel-button"
-              onClick={() => setNotesPanelOpen((p) => !p)}
+              onClick={toggleNotesPanel}
               className="text-gray-500 hover:text-gray-300 transition-colors px-1.5 py-0.5"
               title="Notes panel (Ctrl+Shift+J)"
             >
               <StickyNote size={13} />
             </button>
             <button
-              onClick={() => setPublishedSnapshotsOpen((prev) => !prev)}
+              onClick={togglePublishedSnapshots}
               className="text-gray-500 hover:text-gray-300 transition-colors px-2 py-0.5 text-xs"
               title="History — published versions & snapshots (Ctrl+Shift+H)"
             >
@@ -640,34 +676,59 @@ export function AppShell() {
           />
         </div>
 
-        {publishedSnapshotsOpen && !distractionFree && (
-          <PublishedSnapshotsBrowser
-            onOpenPublishModal={() => setPublishModalOpen(true)}
-            onRestoreSnapshot={handleRestoreSnapshot}
-            onClose={() => setPublishedSnapshotsOpen(false)}
-          />
-        )}
-
-        {characterPanelOpen && !distractionFree && (
-          <CharacterPanel
-            open={characterPanelOpen}
-            onClose={() => setCharacterPanelOpen(false)}
-            editorView={editorView}
-            onOpenCharacterSheet={() => {
-              setCharacterPanelOpen(false)
-              setCharacterSheetOpen(true)
-            }}
-          />
-        )}
-
-        {notesPanelOpen && !distractionFree && (
-          <NotesPanel
-            open={notesPanelOpen}
-            onClose={() => setNotesPanelOpen(false)}
-            editorView={editorView}
-            focusedNoteId={focusedNoteId}
-            onFocusHandled={clearFocusedNote}
-            onEditNote={openNoteEditor}
+        {!distractionFree && (
+          <RightPanelShell
+            panels={[
+              {
+                key: 'characters',
+                label: 'Characters',
+                open: characterPanelOpen,
+                onClose: () => setCharacterPanelOpen(false),
+                content: (
+                  <CharacterPanel
+                    open={characterPanelOpen}
+                    onClose={() => setCharacterPanelOpen(false)}
+                    editorView={editorView}
+                    onOpenCharacterSheet={() => {
+                      setCharacterPanelOpen(false)
+                      setCharacterSheetOpen(true)
+                    }}
+                    embedded
+                  />
+                ),
+              },
+              {
+                key: 'notes',
+                label: 'Notes',
+                open: notesPanelOpen,
+                onClose: () => setNotesPanelOpen(false),
+                content: (
+                  <NotesPanel
+                    open={notesPanelOpen}
+                    onClose={() => setNotesPanelOpen(false)}
+                    editorView={editorView}
+                    focusedNoteId={focusedNoteId}
+                    onFocusHandled={clearFocusedNote}
+                    onEditNote={openNoteEditor}
+                    embedded
+                  />
+                ),
+              },
+              {
+                key: 'history',
+                label: 'History',
+                open: publishedSnapshotsOpen,
+                onClose: () => setPublishedSnapshotsOpen(false),
+                content: (
+                  <PublishedSnapshotsBrowser
+                    onOpenPublishModal={() => setPublishModalOpen(true)}
+                    onRestoreSnapshot={handleRestoreSnapshot}
+                    onClose={() => setPublishedSnapshotsOpen(false)}
+                    embedded
+                  />
+                ),
+              },
+            ] as RightPanel[]}
           />
         )}
 

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback, useEffect, useRef, useMemo } from 'react'
 import type { EditorView } from '@codemirror/view'
-import { Coins, Search } from 'lucide-react'
+import { Coins, Search, StickyNote } from 'lucide-react'
 import { Sidebar } from '../sidebar/Sidebar'
 import Editor from '../editor/Editor'
 import BubbleToolbar from '../editor/BubbleToolbar'
@@ -24,6 +24,7 @@ import { QuestReminder } from '../quests/QuestReminder'
 import { CharacterSheetModal } from '../characters/CharacterSheetModal'
 import { CharacterPanel } from '../characters/CharacterPanel'
 import { DeltaEditorModal } from '../characters/DeltaEditorModal'
+import { NotesPanel } from '../notes/NotesPanel'
 import { useImageRevealStore } from '../../stores/imageRevealStore'
 import { usePublishSyncStore } from '../../stores/publishSyncStore'
 import { getPublishedSnapshots } from '../../stores/publishedSnapshotStore'
@@ -57,6 +58,7 @@ export function AppShell() {
   const [guildTab, setGuildTab] = useState<GuildTab>('board')
   const [characterSheetOpen, setCharacterSheetOpen] = useState(false)
   const [characterPanelOpen, setCharacterPanelOpen] = useState(false)
+  const [notesPanelOpen, setNotesPanelOpen] = useState(false)
   const [deltaEditorState, setDeltaEditorState] = useState<{
     open: boolean
     markerId: string | null
@@ -253,6 +255,11 @@ export function AppShell() {
         setCharacterPanelOpen((p) => !p)
         return
       }
+      if (km.toggleNotesPanel && matchesEvent(km.toggleNotesPanel, e)) {
+        e.preventDefault()
+        setNotesPanelOpen((p) => !p)
+        return
+      }
       if (km.insertStatMarker && matchesEvent(km.insertStatMarker, e)) {
         if (!editorViewRef.current) return
         e.preventDefault()
@@ -416,6 +423,7 @@ export function AppShell() {
     { action: 'findInBook', label: 'Find in book', onSelect: () => setFindOpen((prev) => !prev) },
     { action: 'snapshotHistory', label: 'History', onSelect: () => setPublishedSnapshotsOpen((prev) => !prev) },
     { action: 'toggleCharacterPanel', label: 'Character stats', onSelect: () => setCharacterPanelOpen((p) => !p) },
+    { action: 'toggleNotesPanel', label: 'Notes', onSelect: () => setNotesPanelOpen((p) => !p) },
     { action: 'insertStatMarker', label: 'Insert stat change', onSelect: handleInsertStatMarker },
     { action: 'closeBook', label: 'Open new book', onSelect: () => { void useStoryletStore.getState().closeBook() } },
   ]
@@ -507,6 +515,14 @@ export function AppShell() {
               title="Character stats panel (Ctrl+Shift+C)"
             >
               Stats
+            </button>
+            <button
+              data-testid="notes-panel-button"
+              onClick={() => setNotesPanelOpen((p) => !p)}
+              className="text-gray-500 hover:text-gray-300 transition-colors px-1.5 py-0.5"
+              title="Notes panel (Ctrl+Shift+J)"
+            >
+              <StickyNote size={13} />
             </button>
             <button
               onClick={() => setPublishedSnapshotsOpen((prev) => !prev)}
@@ -602,6 +618,13 @@ export function AppShell() {
               setCharacterPanelOpen(false)
               setCharacterSheetOpen(true)
             }}
+          />
+        )}
+
+        {notesPanelOpen && !distractionFree && (
+          <NotesPanel
+            open={notesPanelOpen}
+            onClose={() => setNotesPanelOpen(false)}
           />
         )}
       </div>

--- a/src/components/layout/PublishedSnapshotsBrowser.tsx
+++ b/src/components/layout/PublishedSnapshotsBrowser.tsx
@@ -30,6 +30,8 @@ interface Props {
   onOpenPublishModal: () => void
   onRestoreSnapshot: (content: string) => void
   onClose: () => void
+  /** When true, render only the inner body — skip outer wrapper styling. Shell supplies chrome. */
+  embedded?: boolean
 }
 
 type CopyFormat = 'markdown' | 'html'
@@ -49,7 +51,7 @@ function computeWordDelta(
   return { insertedWords, deletedWords }
 }
 
-export function PublishedSnapshotsBrowser({ onOpenPublishModal, onRestoreSnapshot, onClose }: Props) {
+export function PublishedSnapshotsBrowser({ onOpenPublishModal, onRestoreSnapshot, onClose, embedded = false }: Props) {
   const [snapshots, setSnapshots] = useState<PublishedSnapshot[]>([])
   const [autoSnapshots, setAutoSnapshots] = useState<Snapshot[]>([])
   const [deleteConfirmId, setDeleteConfirmId] = useState<string | null>(null)
@@ -245,7 +247,13 @@ export function PublishedSnapshotsBrowser({ onOpenPublishModal, onRestoreSnapsho
     : null
 
   return (
-    <div className="flex flex-col bg-gray-900 border-l border-gray-700 h-full w-[380px] shrink-0 overflow-hidden">
+    <div
+      className={
+        embedded
+          ? 'flex flex-col h-full overflow-hidden'
+          : 'flex flex-col bg-gray-900 border-l border-gray-700 h-full w-[380px] shrink-0 overflow-hidden'
+      }
+    >
       {/* Header */}
       <div className="flex items-center justify-between px-4 py-3 border-b border-gray-700">
         {previewEntry ? (
@@ -314,12 +322,14 @@ export function PublishedSnapshotsBrowser({ onOpenPublishModal, onRestoreSnapsho
               <Send size={12} />
               Publish
             </button>
-            <button
-              onClick={onClose}
-              className="text-gray-500 hover:text-gray-300 text-xs"
-            >
-              Close
-            </button>
+            {!embedded && (
+              <button
+                onClick={onClose}
+                className="text-gray-500 hover:text-gray-300 text-xs"
+              >
+                Close
+              </button>
+            )}
           </div>
         )}
       </div>

--- a/src/components/layout/RightPanelShell.tsx
+++ b/src/components/layout/RightPanelShell.tsx
@@ -1,0 +1,104 @@
+import { useMemo, type ReactNode } from 'react'
+import { X } from 'lucide-react'
+import { useEditorStore } from '../../stores/editorStore'
+import type { RightPanelTab } from '../../types'
+
+export interface RightPanel {
+  key: RightPanelTab
+  label: string
+  open: boolean
+  onClose: () => void
+  content: ReactNode
+}
+
+interface Props {
+  panels: RightPanel[]
+}
+
+/**
+ * Unified right-side dock. When exactly one panel is open, renders it
+ * full-bleed with no tab bar (preserves the pre-tab look). When >1 is open,
+ * renders a tab bar across the top — one tab per open panel, active tab fills
+ * the body. The active tab is persisted via editorStore.rightPanelActiveTab.
+ */
+export function RightPanelShell({ panels }: Props) {
+  const activeTabPersisted = useEditorStore((s) => s.rightPanelActiveTab)
+  const setRightPanelActiveTab = useEditorStore((s) => s.setRightPanelActiveTab)
+
+  const openPanels = useMemo(() => panels.filter((p) => p.open), [panels])
+
+  // Resolve which tab is active. Always falls back to an open panel so we
+  // never render a "none selected" body. Purely derived — no state writes
+  // during render or effects (avoid cross-component setState warnings).
+  const activeKey: RightPanelTab | null = useMemo(() => {
+    if (openPanels.length === 0) return null
+    if (
+      activeTabPersisted &&
+      openPanels.some((p) => p.key === activeTabPersisted)
+    ) {
+      return activeTabPersisted
+    }
+    return openPanels[0].key
+  }, [openPanels, activeTabPersisted])
+
+  if (openPanels.length === 0) return null
+
+  const activePanel = openPanels.find((p) => p.key === activeKey) ?? openPanels[0]
+  const showTabs = openPanels.length > 1
+
+  // Width matches the widest panel (history/snapshots). When only one panel is
+  // open, its own embedded wrapper handles layout and fills the shell width.
+  const widthClass = 'w-[360px]'
+
+  return (
+    <div
+      data-testid="right-panel-shell"
+      className={`flex flex-col bg-gray-900 border-l border-gray-700 h-full ${widthClass} shrink-0 overflow-hidden`}
+    >
+      {showTabs && (
+        <div
+          data-testid="right-panel-tabs"
+          className="flex border-b border-gray-700 bg-gray-900/60 shrink-0"
+        >
+          {openPanels.map((panel) => {
+            const isActive = panel.key === activeKey
+            return (
+              <div
+                key={panel.key}
+                data-testid={`right-panel-tab-${panel.key}`}
+                className={`flex items-center flex-1 min-w-0 border-b-2 transition-colors ${
+                  isActive
+                    ? 'border-blue-400 bg-gray-800/70'
+                    : 'border-transparent hover:bg-gray-800/30'
+                }`}
+              >
+                <button
+                  onClick={() => setRightPanelActiveTab(panel.key)}
+                  className={`flex-1 min-w-0 px-3 py-2 text-xs text-left truncate ${
+                    isActive
+                      ? 'text-gray-100'
+                      : 'text-gray-500 hover:text-gray-300'
+                  }`}
+                >
+                  {panel.label}
+                </button>
+                <button
+                  data-testid={`right-panel-tab-${panel.key}-close`}
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    panel.onClose()
+                  }}
+                  title={`Close ${panel.label}`}
+                  className="p-1 mr-1 text-gray-500 hover:text-gray-200 rounded hover:bg-gray-700/60 transition-colors"
+                >
+                  <X size={12} />
+                </button>
+              </div>
+            )
+          })}
+        </div>
+      )}
+      <div className="flex-1 min-h-0 overflow-hidden">{activePanel.content}</div>
+    </div>
+  )
+}

--- a/src/components/notes/ColorPickerPopover.tsx
+++ b/src/components/notes/ColorPickerPopover.tsx
@@ -1,0 +1,133 @@
+import { useEffect, useRef } from 'react'
+import { useEditorStore } from '../../stores/editorStore'
+
+interface Props {
+  open: boolean
+  onClose: () => void
+  currentColor?: string
+  onSelect: (color: string | undefined) => void
+  anchorRect: { top: number; left: number }
+}
+
+const PRESET_COLORS = [
+  '#f87171', // red-400
+  '#fb923c', // orange-400
+  '#fbbf24', // amber-400
+  '#facc15', // yellow-400
+  '#a3e635', // lime-400
+  '#4ade80', // green-400
+  '#34d399', // emerald-400
+  '#22d3ee', // cyan-400
+  '#60a5fa', // blue-400
+  '#818cf8', // indigo-400
+  '#c084fc', // purple-400
+  '#f472b6', // pink-400
+]
+
+/**
+ * Small popover with preset palette + recentColors strip. Not an icon picker.
+ * Calls `useEditorStore.pushRecentColor` whenever a color is selected so the
+ * MRU list stays fresh across the app.
+ */
+export function ColorPickerPopover({
+  open,
+  onClose,
+  currentColor,
+  onSelect,
+  anchorRect,
+}: Props) {
+  const ref = useRef<HTMLDivElement>(null)
+  const recentColors = useEditorStore((s) => s.recentColors)
+  const pushRecentColor = useEditorStore((s) => s.pushRecentColor)
+
+  useEffect(() => {
+    if (!open) return
+    function onDown(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) onClose()
+    }
+    const t = setTimeout(
+      () => document.addEventListener('mousedown', onDown),
+      0,
+    )
+    return () => {
+      clearTimeout(t)
+      document.removeEventListener('mousedown', onDown)
+    }
+  }, [open, onClose])
+
+  if (!open) return null
+
+  function handleSelect(color: string | undefined) {
+    if (color) pushRecentColor(color)
+    onSelect(color)
+    onClose()
+  }
+
+  // Clamp to viewport.
+  const width = 200
+  const maxHeight = 220
+  let top = anchorRect.top
+  let left = anchorRect.left
+  if (left + width > window.innerWidth - 8) left = window.innerWidth - width - 8
+  if (top + maxHeight > window.innerHeight - 8)
+    top = window.innerHeight - maxHeight - 8
+  if (left < 8) left = 8
+  if (top < 8) top = 8
+
+  return (
+    <div
+      ref={ref}
+      data-testid="note-color-popover"
+      className="fixed z-50 bg-gray-800 border border-gray-700 rounded-lg shadow-xl p-2"
+      style={{ top, left, width }}
+      onClick={(e) => e.stopPropagation()}
+    >
+      <div className="text-[10px] uppercase tracking-wider text-gray-500 mb-1">
+        Preset
+      </div>
+      <div className="grid grid-cols-6 gap-1.5 mb-2">
+        {PRESET_COLORS.map((color) => (
+          <button
+            key={color}
+            data-testid="note-color-swatch"
+            data-color={color}
+            className={`w-6 h-6 rounded transition-transform hover:scale-110 ${
+              currentColor === color ? 'ring-2 ring-white' : ''
+            }`}
+            style={{ backgroundColor: color }}
+            title={color}
+            onClick={() => handleSelect(color)}
+          />
+        ))}
+      </div>
+
+      {recentColors.length > 0 && (
+        <>
+          <div className="text-[10px] uppercase tracking-wider text-gray-500 mb-1">
+            Recent
+          </div>
+          <div className="flex flex-wrap gap-1.5 mb-2">
+            {recentColors.map((color) => (
+              <button
+                key={color}
+                className={`w-5 h-5 rounded transition-transform hover:scale-110 ${
+                  currentColor === color ? 'ring-2 ring-white' : ''
+                }`}
+                style={{ backgroundColor: color }}
+                title={color}
+                onClick={() => handleSelect(color)}
+              />
+            ))}
+          </div>
+        </>
+      )}
+
+      <button
+        className="text-[11px] text-gray-400 hover:text-white px-1"
+        onClick={() => handleSelect(undefined)}
+      >
+        Remove color
+      </button>
+    </div>
+  )
+}

--- a/src/components/notes/NoteEditorModal.tsx
+++ b/src/components/notes/NoteEditorModal.tsx
@@ -1,0 +1,183 @@
+import { useEffect, useRef, useState } from 'react'
+import type { EditorView } from '@codemirror/view'
+import { useNotesStore } from '../../stores/notesStore'
+import { NOTE_MARKER_REGEX } from '../../lib/noteUtils'
+
+interface Props {
+  open: boolean
+  onClose: () => void
+  noteId: string | null
+  mode: 'create' | 'edit'
+  editorView: EditorView | null
+}
+
+export function NoteEditorModal({
+  open,
+  onClose,
+  noteId,
+  mode,
+  editorView,
+}: Props) {
+  const panelRef = useRef<HTMLDivElement>(null)
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const note = useNotesStore((s) =>
+    noteId ? s.positionNotes[noteId] : undefined,
+  )
+  const updatePositionNote = useNotesStore((s) => s.updatePositionNote)
+  const removePositionNote = useNotesStore((s) => s.removePositionNote)
+
+  const [body, setBody] = useState<string>('')
+  const [confirmDelete, setConfirmDelete] = useState(false)
+
+  // Seed draft whenever the modal opens (or the target note changes).
+  useEffect(() => {
+    if (!open) return
+    setConfirmDelete(false)
+    setBody(note?.body ?? '')
+    // Focus the textarea after the panel renders.
+    const t = setTimeout(() => textareaRef.current?.focus(), 0)
+    return () => clearTimeout(t)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, noteId])
+
+  // Escape to close.
+  useEffect(() => {
+    if (!open) return
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        onClose()
+      }
+    }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [open, onClose])
+
+  // Outside click to close. Defer registration by one tick so the click
+  // that opened the modal doesn't immediately close it.
+  useEffect(() => {
+    if (!open) return
+    function onDown(e: MouseEvent) {
+      if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
+        onClose()
+      }
+    }
+    const t = setTimeout(() => document.addEventListener('mousedown', onDown), 0)
+    return () => {
+      clearTimeout(t)
+      document.removeEventListener('mousedown', onDown)
+    }
+  }, [open, onClose])
+
+  if (!open || !noteId) return null
+
+  function handleSave() {
+    if (!noteId) return
+    updatePositionNote(noteId, { body })
+    onClose()
+  }
+
+  function handleDelete() {
+    if (!noteId) return
+    if (editorView) {
+      const doc = editorView.state.doc.toString()
+      const re = new RegExp(NOTE_MARKER_REGEX.source, 'g')
+      let m: RegExpExecArray | null
+      while ((m = re.exec(doc)) !== null) {
+        if (m[1] === noteId) {
+          editorView.dispatch({
+            changes: { from: m.index, to: m.index + m[0].length, insert: '' },
+          })
+          break
+        }
+      }
+    }
+    removePositionNote(noteId)
+    onClose()
+  }
+
+  const shortId = noteId.slice(0, 8)
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
+      <div
+        ref={panelRef}
+        data-testid="note-editor-modal"
+        className="w-[min(92vw,640px)] max-h-[90vh] bg-gray-900 border border-gray-700 rounded-xl shadow-2xl flex flex-col"
+      >
+        <div className="flex items-center justify-between px-5 py-3 border-b border-gray-700 shrink-0">
+          <div className="flex flex-col">
+            <span className="text-sm font-medium text-gray-200">
+              {mode === 'create' ? 'New Note' : 'Edit Note'}
+            </span>
+            <span className="text-[11px] text-gray-500 font-mono">{shortId}</span>
+          </div>
+          <button
+            onClick={onClose}
+            className="text-gray-500 hover:text-gray-300 transition-colors text-xs"
+          >
+            Close
+          </button>
+        </div>
+
+        <div className="flex-1 min-h-0 overflow-y-auto p-5">
+          <label className="block text-xs text-gray-400 mb-1">Body</label>
+          <textarea
+            ref={textareaRef}
+            data-testid="note-editor-body"
+            value={body}
+            onChange={(e) => setBody(e.target.value)}
+            placeholder="Write a note…"
+            className="w-full min-h-[160px] resize-y bg-gray-800 border border-gray-700 rounded px-2 py-1.5 text-sm text-gray-200 placeholder:text-gray-600 outline-none focus:border-blue-500"
+          />
+        </div>
+
+        <div className="flex items-center justify-between gap-2 border-t border-gray-700 px-5 py-3 shrink-0">
+          <div className="flex items-center gap-2">
+            {confirmDelete ? (
+              <div className="flex items-center gap-1">
+                <span className="text-xs text-gray-400">Delete note?</span>
+                <button
+                  data-testid="note-editor-delete-confirm"
+                  onClick={handleDelete}
+                  className="text-xs bg-red-900 hover:bg-red-800 text-red-200 rounded px-2 py-1"
+                >
+                  Yes
+                </button>
+                <button
+                  onClick={() => setConfirmDelete(false)}
+                  className="text-xs bg-gray-700 hover:bg-gray-600 text-gray-300 rounded px-2 py-1"
+                >
+                  Cancel
+                </button>
+              </div>
+            ) : (
+              <button
+                data-testid="note-editor-delete"
+                onClick={() => setConfirmDelete(true)}
+                className="text-xs text-red-400 hover:text-red-300 border border-red-900/50 hover:border-red-700 rounded px-2 py-1"
+              >
+                Delete note
+              </button>
+            )}
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={onClose}
+              className="text-xs bg-gray-700 hover:bg-gray-600 text-gray-200 rounded px-2 py-1"
+            >
+              Cancel
+            </button>
+            <button
+              data-testid="note-editor-save"
+              onClick={handleSave}
+              className="text-xs bg-blue-600 hover:bg-blue-500 text-white rounded px-3 py-1"
+            >
+              Save
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/notes/NoteEditorModal.tsx
+++ b/src/components/notes/NoteEditorModal.tsx
@@ -2,6 +2,8 @@ import { useEffect, useRef, useState } from 'react'
 import type { EditorView } from '@codemirror/view'
 import { useNotesStore } from '../../stores/notesStore'
 import { NOTE_MARKER_REGEX } from '../../lib/noteUtils'
+import { TagChipInput } from './TagChipInput'
+import { ColorPickerPopover } from './ColorPickerPopover'
 
 interface Props {
   open: boolean
@@ -20,6 +22,7 @@ export function NoteEditorModal({
 }: Props) {
   const panelRef = useRef<HTMLDivElement>(null)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const colorButtonRef = useRef<HTMLButtonElement>(null)
   const note = useNotesStore((s) =>
     noteId ? s.positionNotes[noteId] : undefined,
   )
@@ -27,13 +30,23 @@ export function NoteEditorModal({
   const removePositionNote = useNotesStore((s) => s.removePositionNote)
 
   const [body, setBody] = useState<string>('')
+  const [tags, setTags] = useState<string[]>([])
+  const [color, setColor] = useState<string | undefined>(undefined)
   const [confirmDelete, setConfirmDelete] = useState(false)
+  const [colorPickerOpen, setColorPickerOpen] = useState(false)
+  const [colorAnchorRect, setColorAnchorRect] = useState<{
+    top: number
+    left: number
+  }>({ top: 0, left: 0 })
 
   // Seed draft whenever the modal opens (or the target note changes).
   useEffect(() => {
     if (!open) return
     setConfirmDelete(false)
+    setColorPickerOpen(false)
     setBody(note?.body ?? '')
+    setTags(note?.tags ?? [])
+    setColor(note?.color)
     // Focus the textarea after the panel renders.
     const t = setTimeout(() => textareaRef.current?.focus(), 0)
     return () => clearTimeout(t)
@@ -73,7 +86,7 @@ export function NoteEditorModal({
 
   function handleSave() {
     if (!noteId) return
-    updatePositionNote(noteId, { body })
+    updatePositionNote(noteId, { body, tags, color })
     onClose()
   }
 
@@ -94,6 +107,13 @@ export function NoteEditorModal({
     }
     removePositionNote(noteId)
     onClose()
+  }
+
+  function openColorPicker() {
+    const rect = colorButtonRef.current?.getBoundingClientRect()
+    if (!rect) return
+    setColorAnchorRect({ top: rect.bottom + 4, left: rect.left })
+    setColorPickerOpen(true)
   }
 
   const shortId = noteId.slice(0, 8)
@@ -120,16 +140,50 @@ export function NoteEditorModal({
           </button>
         </div>
 
-        <div className="flex-1 min-h-0 overflow-y-auto p-5">
-          <label className="block text-xs text-gray-400 mb-1">Body</label>
-          <textarea
-            ref={textareaRef}
-            data-testid="note-editor-body"
-            value={body}
-            onChange={(e) => setBody(e.target.value)}
-            placeholder="Write a note…"
-            className="w-full min-h-[160px] resize-y bg-gray-800 border border-gray-700 rounded px-2 py-1.5 text-sm text-gray-200 placeholder:text-gray-600 outline-none focus:border-blue-500"
-          />
+        <div className="flex-1 min-h-0 overflow-y-auto p-5 space-y-4">
+          <div>
+            <label className="block text-xs text-gray-400 mb-1">Body</label>
+            <textarea
+              ref={textareaRef}
+              data-testid="note-editor-body"
+              value={body}
+              onChange={(e) => setBody(e.target.value)}
+              placeholder="Write a note…"
+              className="w-full min-h-[160px] resize-y bg-gray-800 border border-gray-700 rounded px-2 py-1.5 text-sm text-gray-200 placeholder:text-gray-600 outline-none focus:border-blue-500"
+            />
+          </div>
+
+          <div>
+            <label className="block text-xs text-gray-400 mb-1">Tags</label>
+            <TagChipInput
+              tags={tags}
+              onChange={setTags}
+              placeholder="Add tag and press Enter"
+              testId="note-editor-tags"
+            />
+          </div>
+
+          <div>
+            <label className="block text-xs text-gray-400 mb-1">Color</label>
+            <button
+              ref={colorButtonRef}
+              type="button"
+              onClick={openColorPicker}
+              data-testid="note-editor-color-button"
+              className="inline-flex items-center gap-2 bg-gray-800 hover:bg-gray-700 border border-gray-700 rounded px-2 py-1 text-xs text-gray-200"
+            >
+              <span
+                className="w-4 h-4 rounded border border-gray-600"
+                style={{
+                  backgroundColor: color ?? 'transparent',
+                  backgroundImage: color
+                    ? undefined
+                    : 'repeating-linear-gradient(45deg,#374151,#374151 3px,#4b5563 3px,#4b5563 6px)',
+                }}
+              />
+              <span className="font-mono">{color ?? 'none'}</span>
+            </button>
+          </div>
         </div>
 
         <div className="flex items-center justify-between gap-2 border-t border-gray-700 px-5 py-3 shrink-0">
@@ -178,6 +232,14 @@ export function NoteEditorModal({
           </div>
         </div>
       </div>
+
+      <ColorPickerPopover
+        open={colorPickerOpen}
+        onClose={() => setColorPickerOpen(false)}
+        currentColor={color}
+        onSelect={(c) => setColor(c)}
+        anchorRect={colorAnchorRect}
+      />
     </div>
   )
 }

--- a/src/components/notes/NotesPanel.tsx
+++ b/src/components/notes/NotesPanel.tsx
@@ -5,6 +5,8 @@ import { useNotesStore } from '../../stores/notesStore'
 import { useStoryletStore } from '../../stores/storyletStore'
 import { extractNotes } from '../../lib/noteUtils'
 import type { PositionNote, Storylet, StoryletNote } from '../../types'
+import { TagChipInput } from './TagChipInput'
+import { ColorPickerPopover } from './ColorPickerPopover'
 
 interface Props {
   open: boolean
@@ -35,9 +37,19 @@ function nowIso(): string {
   return new Date().toISOString()
 }
 
+/** A note matches when it contains every active filter tag (AND semantics). */
+function matchesTagFilter(
+  noteTags: string[] | undefined,
+  filter: string[],
+): boolean {
+  if (filter.length === 0) return true
+  if (!noteTags || noteTags.length === 0) return false
+  return filter.every((f) => noteTags.includes(f))
+}
+
 // ---------------------------------------------------------------------------
-// StoryletNoteRow — inline-edited textarea with debounced auto-save (400ms).
-// Also renders a small trash button with a two-step confirm.
+// StoryletNoteRow — inline-edited textarea + tag chips + color swatch with
+// debounced auto-save (400ms).
 // ---------------------------------------------------------------------------
 
 interface StoryletNoteRowProps {
@@ -54,7 +66,10 @@ function StoryletNoteRow({ storyletId, note }: StoryletNoteRowProps) {
     note.updatedAt,
   )
   const [confirmDelete, setConfirmDelete] = useState(false)
+  const [colorPickerOpen, setColorPickerOpen] = useState(false)
+  const [colorAnchor, setColorAnchor] = useState({ top: 0, left: 0 })
   const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const colorSwatchRef = useRef<HTMLButtonElement>(null)
 
   // Reconcile external updates (file load, undo) using the "derived state
   // from props" pattern. When the store-owned updatedAt moves forward and we
@@ -88,6 +103,13 @@ function StoryletNoteRow({ storyletId, note }: StoryletNoteRowProps) {
     [storyletId, note.id, updateStoryletNote],
   )
 
+  const handleTagsChange = useCallback(
+    (tags: string[]) => {
+      updateStoryletNote(storyletId, note.id, { tags })
+    },
+    [storyletId, note.id, updateStoryletNote],
+  )
+
   const handleDelete = useCallback(() => {
     if (saveTimer.current !== null) {
       clearTimeout(saveTimer.current)
@@ -96,47 +118,88 @@ function StoryletNoteRow({ storyletId, note }: StoryletNoteRowProps) {
     removeStoryletNote(storyletId, note.id)
   }, [storyletId, note.id, removeStoryletNote])
 
+  function openColorPicker() {
+    const rect = colorSwatchRef.current?.getBoundingClientRect()
+    if (!rect) return
+    setColorAnchor({ top: rect.bottom + 4, left: rect.left })
+    setColorPickerOpen(true)
+  }
+
+  const color = note.color
+
   return (
     <div
       data-testid="storylet-note-row"
       data-note-id={note.id}
-      className="relative group"
+      className="relative group space-y-1"
     >
-      <textarea
-        data-testid="storylet-note-textarea"
-        value={draft}
-        onChange={(e) => handleChange(e.target.value)}
-        placeholder="Write a storylet note…"
-        className="w-full min-h-[60px] resize-none bg-gray-800/40 border border-gray-700 rounded px-2 py-1.5 pr-7 text-sm text-gray-200 placeholder:text-gray-600 focus:outline-none focus:border-blue-500"
-      />
-      <div className="absolute top-1 right-1 flex items-center gap-1">
-        {confirmDelete ? (
-          <>
-            <button
-              data-testid="storylet-note-delete-confirm"
-              onClick={handleDelete}
-              className="text-[10px] bg-red-900 hover:bg-red-800 text-red-200 rounded px-1.5 py-0.5"
-            >
-              Yes
-            </button>
-            <button
-              onClick={() => setConfirmDelete(false)}
-              className="text-[10px] bg-gray-700 hover:bg-gray-600 text-gray-300 rounded px-1.5 py-0.5"
-            >
-              No
-            </button>
-          </>
-        ) : (
+      <div className="relative">
+        <textarea
+          data-testid="storylet-note-textarea"
+          value={draft}
+          onChange={(e) => handleChange(e.target.value)}
+          placeholder="Write a storylet note…"
+          className="w-full min-h-[60px] resize-none bg-gray-800/40 border border-gray-700 rounded px-2 py-1.5 pr-14 text-sm text-gray-200 placeholder:text-gray-600 focus:outline-none focus:border-blue-500"
+        />
+        <div className="absolute top-1 right-1 flex items-center gap-1">
           <button
-            data-testid="storylet-note-delete"
-            onClick={() => setConfirmDelete(true)}
-            title="Delete note"
-            className="opacity-0 group-hover:opacity-100 focus:opacity-100 text-gray-500 hover:text-red-400 p-0.5 transition-opacity"
-          >
-            <Trash2 size={12} />
-          </button>
-        )}
+            ref={colorSwatchRef}
+            type="button"
+            onClick={openColorPicker}
+            title={color ? `Color ${color}` : 'Set color'}
+            className="w-3.5 h-3.5 rounded border border-gray-600"
+            style={{
+              backgroundColor: color ?? 'transparent',
+              backgroundImage: color
+                ? undefined
+                : 'repeating-linear-gradient(45deg,#374151,#374151 2px,#4b5563 2px,#4b5563 4px)',
+            }}
+            data-testid="storylet-note-color"
+          />
+          {confirmDelete ? (
+            <>
+              <button
+                data-testid="storylet-note-delete-confirm"
+                onClick={handleDelete}
+                className="text-[10px] bg-red-900 hover:bg-red-800 text-red-200 rounded px-1.5 py-0.5"
+              >
+                Yes
+              </button>
+              <button
+                onClick={() => setConfirmDelete(false)}
+                className="text-[10px] bg-gray-700 hover:bg-gray-600 text-gray-300 rounded px-1.5 py-0.5"
+              >
+                No
+              </button>
+            </>
+          ) : (
+            <button
+              data-testid="storylet-note-delete"
+              onClick={() => setConfirmDelete(true)}
+              title="Delete note"
+              className="opacity-0 group-hover:opacity-100 focus:opacity-100 text-gray-500 hover:text-red-400 p-0.5 transition-opacity"
+            >
+              <Trash2 size={12} />
+            </button>
+          )}
+        </div>
       </div>
+      <TagChipInput
+        tags={note.tags ?? []}
+        onChange={handleTagsChange}
+        placeholder="tag"
+        size="sm"
+        testId="storylet-note-tags"
+      />
+      <ColorPickerPopover
+        open={colorPickerOpen}
+        onClose={() => setColorPickerOpen(false)}
+        currentColor={color}
+        onSelect={(c) => {
+          updateStoryletNote(storyletId, note.id, { color: c })
+        }}
+        anchorRect={colorAnchor}
+      />
     </div>
   )
 }
@@ -221,6 +284,9 @@ export function NotesPanel({
   const storyletNotes = useNotesStore((s) => s.storyletNotes)
   const rowRefs = useRef<Map<string, HTMLLIElement>>(new Map())
 
+  // Tag filter — chips with AND semantics across all note kinds.
+  const [filterTags, setFilterTags] = useState<string[]>([])
+
   // Jump from a panel row to the anchor in the editor. Mirrors
   // CharacterPanel.jumpToMarker but uses the notesStore / noteUtils pattern.
   const jumpToNote = useCallback(
@@ -274,7 +340,8 @@ export function NotesPanel({
   }, [focusedNoteId, open, onFocusHandled])
 
   // Active storylet (or fallback to first) is pinned at the top. Any other
-  // storylets with notes render below in a secondary list.
+  // storylets with notes render below in a secondary list. Filtering applies
+  // after the section structure so storylet headers stay meaningful.
   const storyletNotesSections = useMemo<{
     active: StoryletNotesSection | null
     others: StoryletNotesSection[]
@@ -285,8 +352,11 @@ export function NotesPanel({
       book.storylets[0] ??
       null
 
+    const filterList = (notes: StoryletNote[]) =>
+      notes.filter((n) => matchesTagFilter(n.tags, filterTags))
+
     const activeSection: StoryletNotesSection | null = active
-      ? { storylet: active, notes: storyletNotes[active.id] ?? [] }
+      ? { storylet: active, notes: filterList(storyletNotes[active.id] ?? []) }
       : null
 
     const others: StoryletNotesSection[] = []
@@ -294,10 +364,12 @@ export function NotesPanel({
       if (active && storylet.id === active.id) continue
       const notes = storyletNotes[storylet.id]
       if (!notes || notes.length === 0) continue
-      others.push({ storylet, notes })
+      const filtered = filterList(notes)
+      if (filtered.length === 0) continue
+      others.push({ storylet, notes: filtered })
     }
     return { active: activeSection, others }
-  }, [book, activeStoryletId, storyletNotes])
+  }, [book, activeStoryletId, storyletNotes, filterTags])
 
   const sections = useMemo<StoryletSection[]>(() => {
     if (!book) return []
@@ -305,22 +377,25 @@ export function NotesPanel({
     for (const storylet of book.storylets) {
       const extracted = extractNotes(storylet.content ?? '')
       if (extracted.length === 0) continue
-      out.push({
-        storylet,
-        notes: extracted.map((n) => ({
+      const filtered = extracted
+        .map((n) => ({
           id: n.id,
           offset: n.offset,
           note: positionNotes[n.id],
-        })),
-      })
+        }))
+        .filter((row) => matchesTagFilter(row.note?.tags, filterTags))
+      if (filtered.length === 0) continue
+      out.push({ storylet, notes: filtered })
     }
     return out
-  }, [book, positionNotes])
+  }, [book, positionNotes, filterTags])
 
   const totalPositionNotes = useMemo(
     () => sections.reduce((sum, s) => sum + s.notes.length, 0),
     [sections],
   )
+
+  const filterActive = filterTags.length > 0
 
   if (!open) return null
 
@@ -340,37 +415,67 @@ export function NotesPanel({
         </button>
       </div>
 
+      {/* Filter bar */}
+      <div className="px-3 py-2 border-b border-gray-800 bg-gray-900/60">
+        <div className="flex items-center gap-1.5 mb-1">
+          <span className="text-[10px] uppercase tracking-wider text-gray-500 font-semibold">
+            Filter
+          </span>
+          {filterActive && (
+            <button
+              data-testid="notes-panel-filter-clear"
+              onClick={() => setFilterTags([])}
+              className="text-[10px] text-gray-500 hover:text-gray-200"
+            >
+              clear
+            </button>
+          )}
+        </div>
+        <TagChipInput
+          tags={filterTags}
+          onChange={setFilterTags}
+          placeholder="Filter by tag…"
+          size="sm"
+          testId="notes-panel-filter"
+        />
+      </div>
+
       {/* Body */}
       <div className="flex-1 overflow-y-auto px-3 py-3 space-y-4">
         {/* Pinned: Storylet notes ----------------------------------------- */}
-        {storyletNotesSections.active && (
-          <section
-            data-testid="storylet-notes-section"
-            className="space-y-3"
-          >
-            <div className="text-[10px] uppercase tracking-wider text-gray-500 font-semibold">
-              Storylet notes
-            </div>
-            <StoryletNotesGroup
-              storylet={storyletNotesSections.active.storylet}
-              notes={storyletNotesSections.active.notes}
-            />
-            {storyletNotesSections.others.length > 0 && (
-              <div
-                data-testid="storylet-notes-others"
-                className="pt-2 border-t border-gray-800 space-y-3"
-              >
-                {storyletNotesSections.others.map((s) => (
-                  <StoryletNotesGroup
-                    key={s.storylet.id}
-                    storylet={s.storylet}
-                    notes={s.notes}
-                  />
-                ))}
+        {storyletNotesSections.active &&
+          (storyletNotesSections.active.notes.length > 0 ||
+            !filterActive ||
+            storyletNotesSections.others.length > 0) && (
+            <section
+              data-testid="storylet-notes-section"
+              className="space-y-3"
+            >
+              <div className="text-[10px] uppercase tracking-wider text-gray-500 font-semibold">
+                Storylet notes
               </div>
-            )}
-          </section>
-        )}
+              {(!filterActive || storyletNotesSections.active.notes.length > 0) && (
+                <StoryletNotesGroup
+                  storylet={storyletNotesSections.active.storylet}
+                  notes={storyletNotesSections.active.notes}
+                />
+              )}
+              {storyletNotesSections.others.length > 0 && (
+                <div
+                  data-testid="storylet-notes-others"
+                  className="pt-2 border-t border-gray-800 space-y-3"
+                >
+                  {storyletNotesSections.others.map((s) => (
+                    <StoryletNotesGroup
+                      key={s.storylet.id}
+                      storylet={s.storylet}
+                      notes={s.notes}
+                    />
+                  ))}
+                </div>
+              )}
+            </section>
+          )}
 
         {/* Position notes ------------------------------------------------- */}
         {totalPositionNotes > 0 && (
@@ -458,6 +563,21 @@ export function NotesPanel({
             ))}
           </section>
         )}
+
+        {/* No-match state when a filter is on but nothing matches. */}
+        {book &&
+          filterActive &&
+          totalPositionNotes === 0 &&
+          (!storyletNotesSections.active ||
+            storyletNotesSections.active.notes.length === 0) &&
+          storyletNotesSections.others.length === 0 && (
+            <div
+              data-testid="notes-panel-no-match"
+              className="text-center text-xs text-gray-500 py-8"
+            >
+              No notes match the current filter.
+            </div>
+          )}
 
         {/* Empty state — only when there is no book at all. */}
         {!book && (

--- a/src/components/notes/NotesPanel.tsx
+++ b/src/components/notes/NotesPanel.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { Trash2 } from 'lucide-react'
+import { CornerDownRight, Pencil, Trash2 } from 'lucide-react'
+import type { EditorView } from '@codemirror/view'
 import { useNotesStore } from '../../stores/notesStore'
 import { useStoryletStore } from '../../stores/storyletStore'
 import { extractNotes } from '../../lib/noteUtils'
@@ -8,6 +9,10 @@ import type { PositionNote, Storylet, StoryletNote } from '../../types'
 interface Props {
   open: boolean
   onClose: () => void
+  editorView: EditorView | null
+  focusedNoteId: string | null
+  onFocusHandled: () => void
+  onEditNote: (noteId: string) => void
 }
 
 interface StoryletSection {
@@ -201,11 +206,72 @@ function StoryletNotesGroup({ storylet, notes }: StoryletNotesGroupProps) {
 // NotesPanel
 // ---------------------------------------------------------------------------
 
-export function NotesPanel({ open, onClose }: Props) {
+export function NotesPanel({
+  open,
+  onClose,
+  editorView,
+  focusedNoteId,
+  onFocusHandled,
+  onEditNote,
+}: Props) {
   const book = useStoryletStore((s) => s.book)
   const activeStoryletId = useStoryletStore((s) => s.activeStoryletId)
+  const setActiveStorylet = useStoryletStore((s) => s.setActiveStorylet)
   const positionNotes = useNotesStore((s) => s.positionNotes)
   const storyletNotes = useNotesStore((s) => s.storyletNotes)
+  const rowRefs = useRef<Map<string, HTMLLIElement>>(new Map())
+
+  // Jump from a panel row to the anchor in the editor. Mirrors
+  // CharacterPanel.jumpToMarker but uses the notesStore / noteUtils pattern.
+  const jumpToNote = useCallback(
+    (noteId: string) => {
+      if (!book) return
+      // Find which storylet contains this anchor + its offset.
+      let targetStoryletId: string | null = null
+      let targetOffset = 0
+      for (const storylet of book.storylets) {
+        const extracted = extractNotes(storylet.content ?? '')
+        const match = extracted.find((n) => n.id === noteId)
+        if (match) {
+          targetStoryletId = storylet.id
+          targetOffset = match.offset
+          break
+        }
+      }
+      if (!targetStoryletId) return
+      const doJump = () => {
+        const v = editorView
+        if (!v) return
+        const len = v.state.doc.length
+        const pos = Math.min(targetOffset, len)
+        v.dispatch({ selection: { anchor: pos }, scrollIntoView: true })
+        v.focus()
+      }
+      if (targetStoryletId !== activeStoryletId) {
+        setActiveStorylet(targetStoryletId)
+        setTimeout(doJump, 30)
+      } else {
+        doJump()
+      }
+    },
+    [book, activeStoryletId, editorView, setActiveStorylet],
+  )
+
+  // Flash + scroll into view when a row becomes focused.
+  useEffect(() => {
+    if (!focusedNoteId || !open) return
+    const el = rowRefs.current.get(focusedNoteId)
+    if (!el) return
+    el.scrollIntoView({ block: 'center', behavior: 'smooth' })
+    el.classList.remove('cm-value-flash')
+    void el.offsetWidth
+    el.classList.add('cm-value-flash')
+    const timer = setTimeout(() => {
+      el.classList.remove('cm-value-flash')
+      onFocusHandled()
+    }, 800)
+    return () => clearTimeout(timer)
+  }, [focusedNoteId, open, onFocusHandled])
 
   // Active storylet (or fallback to first) is pinned at the top. Any other
   // storylets with notes render below in a secondary list.
@@ -333,7 +399,11 @@ export function NotesPanel({ open, onClose }: Props) {
                         key={id}
                         data-testid="notes-panel-note-row"
                         data-note-id={id}
-                        className="flex items-start gap-2 px-2 py-2"
+                        ref={(el) => {
+                          if (el) rowRefs.current.set(id, el)
+                          else rowRefs.current.delete(id)
+                        }}
+                        className="group flex items-start gap-2 px-2 py-2"
                       >
                         <span
                           className="w-2.5 h-2.5 rounded-sm shrink-0 translate-y-[3px]"
@@ -361,6 +431,24 @@ export function NotesPanel({ open, onClose }: Props) {
                               ))}
                             </div>
                           )}
+                        </div>
+                        <div className="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity shrink-0">
+                          <button
+                            data-testid="notes-panel-jump"
+                            onClick={() => jumpToNote(id)}
+                            title="Jump to note in editor"
+                            className="text-gray-500 hover:text-gray-200 p-0.5 rounded hover:bg-gray-800"
+                          >
+                            <CornerDownRight size={12} />
+                          </button>
+                          <button
+                            data-testid="notes-panel-edit"
+                            onClick={() => onEditNote(id)}
+                            title="Edit note"
+                            className="text-gray-500 hover:text-gray-200 p-0.5 rounded hover:bg-gray-800"
+                          >
+                            <Pencil size={12} />
+                          </button>
                         </div>
                       </li>
                     )

--- a/src/components/notes/NotesPanel.tsx
+++ b/src/components/notes/NotesPanel.tsx
@@ -1,8 +1,9 @@
-import { useMemo } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { Trash2 } from 'lucide-react'
 import { useNotesStore } from '../../stores/notesStore'
 import { useStoryletStore } from '../../stores/storyletStore'
 import { extractNotes } from '../../lib/noteUtils'
-import type { PositionNote, Storylet } from '../../types'
+import type { PositionNote, Storylet, StoryletNote } from '../../types'
 
 interface Props {
   open: boolean
@@ -14,15 +15,223 @@ interface StoryletSection {
   notes: Array<{ id: string; offset: number; note: PositionNote | undefined }>
 }
 
+interface StoryletNotesSection {
+  storylet: Storylet
+  notes: StoryletNote[]
+}
+
 function previewBody(body: string): string {
   const collapsed = body.replace(/\s+/g, ' ').trim()
   if (collapsed.length <= 60) return collapsed
   return collapsed.slice(0, 60).trimEnd() + '\u2026'
 }
 
+function nowIso(): string {
+  return new Date().toISOString()
+}
+
+// ---------------------------------------------------------------------------
+// StoryletNoteRow — inline-edited textarea with debounced auto-save (400ms).
+// Also renders a small trash button with a two-step confirm.
+// ---------------------------------------------------------------------------
+
+interface StoryletNoteRowProps {
+  storyletId: string
+  note: StoryletNote
+}
+
+function StoryletNoteRow({ storyletId, note }: StoryletNoteRowProps) {
+  const updateStoryletNote = useNotesStore((s) => s.updateStoryletNote)
+  const removeStoryletNote = useNotesStore((s) => s.removeStoryletNote)
+
+  const [draft, setDraft] = useState<string>(note.body)
+  const [lastSyncedUpdatedAt, setLastSyncedUpdatedAt] = useState<string>(
+    note.updatedAt,
+  )
+  const [confirmDelete, setConfirmDelete] = useState(false)
+  const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // Reconcile external updates (file load, undo) using the "derived state
+  // from props" pattern. When the store-owned updatedAt moves forward and we
+  // have no pending save, re-sync the draft.
+  if (note.updatedAt !== lastSyncedUpdatedAt) {
+    setLastSyncedUpdatedAt(note.updatedAt)
+    if (note.body !== draft) {
+      setDraft(note.body)
+    }
+  }
+
+  // Flush on unmount so we don't lose pending edits when the panel closes.
+  useEffect(() => {
+    return () => {
+      if (saveTimer.current !== null) {
+        clearTimeout(saveTimer.current)
+        saveTimer.current = null
+      }
+    }
+  }, [])
+
+  const handleChange = useCallback(
+    (value: string) => {
+      setDraft(value)
+      if (saveTimer.current !== null) clearTimeout(saveTimer.current)
+      saveTimer.current = setTimeout(() => {
+        updateStoryletNote(storyletId, note.id, { body: value })
+        saveTimer.current = null
+      }, 400)
+    },
+    [storyletId, note.id, updateStoryletNote],
+  )
+
+  const handleDelete = useCallback(() => {
+    if (saveTimer.current !== null) {
+      clearTimeout(saveTimer.current)
+      saveTimer.current = null
+    }
+    removeStoryletNote(storyletId, note.id)
+  }, [storyletId, note.id, removeStoryletNote])
+
+  return (
+    <div
+      data-testid="storylet-note-row"
+      data-note-id={note.id}
+      className="relative group"
+    >
+      <textarea
+        data-testid="storylet-note-textarea"
+        value={draft}
+        onChange={(e) => handleChange(e.target.value)}
+        placeholder="Write a storylet note…"
+        className="w-full min-h-[60px] resize-none bg-gray-800/40 border border-gray-700 rounded px-2 py-1.5 pr-7 text-sm text-gray-200 placeholder:text-gray-600 focus:outline-none focus:border-blue-500"
+      />
+      <div className="absolute top-1 right-1 flex items-center gap-1">
+        {confirmDelete ? (
+          <>
+            <button
+              data-testid="storylet-note-delete-confirm"
+              onClick={handleDelete}
+              className="text-[10px] bg-red-900 hover:bg-red-800 text-red-200 rounded px-1.5 py-0.5"
+            >
+              Yes
+            </button>
+            <button
+              onClick={() => setConfirmDelete(false)}
+              className="text-[10px] bg-gray-700 hover:bg-gray-600 text-gray-300 rounded px-1.5 py-0.5"
+            >
+              No
+            </button>
+          </>
+        ) : (
+          <button
+            data-testid="storylet-note-delete"
+            onClick={() => setConfirmDelete(true)}
+            title="Delete note"
+            className="opacity-0 group-hover:opacity-100 focus:opacity-100 text-gray-500 hover:text-red-400 p-0.5 transition-opacity"
+          >
+            <Trash2 size={12} />
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// StoryletNotesGroup — sub-header + list of storylet notes + "+ Note" button.
+// ---------------------------------------------------------------------------
+
+interface StoryletNotesGroupProps {
+  storylet: Storylet
+  notes: StoryletNote[]
+}
+
+function StoryletNotesGroup({ storylet, notes }: StoryletNotesGroupProps) {
+  const addStoryletNote = useNotesStore((s) => s.addStoryletNote)
+
+  const handleAdd = useCallback(() => {
+    const timestamp = nowIso()
+    const newNote: StoryletNote = {
+      id: crypto.randomUUID(),
+      storyletId: storylet.id,
+      body: '',
+      tags: [],
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    }
+    addStoryletNote(storylet.id, newNote)
+  }, [storylet.id, addStoryletNote])
+
+  return (
+    <div
+      data-testid={`storylet-notes-group-${storylet.id}`}
+      className="space-y-2"
+    >
+      <div className="flex items-center justify-between">
+        <span className="text-[11px] uppercase tracking-wide text-gray-400">
+          {storylet.name}
+        </span>
+        <button
+          data-testid="storylet-note-add"
+          onClick={handleAdd}
+          className="text-[11px] text-gray-400 hover:text-gray-200 bg-gray-800 hover:bg-gray-700 border border-gray-700 rounded px-2 py-0.5"
+        >
+          + Note
+        </button>
+      </div>
+      {notes.length === 0 ? (
+        <div className="text-[11px] text-gray-600 italic px-1">
+          No storylet notes yet.
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {notes.map((note) => (
+            <StoryletNoteRow
+              key={note.id}
+              storyletId={storylet.id}
+              note={note}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// NotesPanel
+// ---------------------------------------------------------------------------
+
 export function NotesPanel({ open, onClose }: Props) {
   const book = useStoryletStore((s) => s.book)
+  const activeStoryletId = useStoryletStore((s) => s.activeStoryletId)
   const positionNotes = useNotesStore((s) => s.positionNotes)
+  const storyletNotes = useNotesStore((s) => s.storyletNotes)
+
+  // Active storylet (or fallback to first) is pinned at the top. Any other
+  // storylets with notes render below in a secondary list.
+  const storyletNotesSections = useMemo<{
+    active: StoryletNotesSection | null
+    others: StoryletNotesSection[]
+  }>(() => {
+    if (!book) return { active: null, others: [] }
+    const active =
+      book.storylets.find((s) => s.id === activeStoryletId) ??
+      book.storylets[0] ??
+      null
+
+    const activeSection: StoryletNotesSection | null = active
+      ? { storylet: active, notes: storyletNotes[active.id] ?? [] }
+      : null
+
+    const others: StoryletNotesSection[] = []
+    for (const storylet of book.storylets) {
+      if (active && storylet.id === active.id) continue
+      const notes = storyletNotes[storylet.id]
+      if (!notes || notes.length === 0) continue
+      others.push({ storylet, notes })
+    }
+    return { active: activeSection, others }
+  }, [book, activeStoryletId, storyletNotes])
 
   const sections = useMemo<StoryletSection[]>(() => {
     if (!book) return []
@@ -42,7 +251,7 @@ export function NotesPanel({ open, onClose }: Props) {
     return out
   }, [book, positionNotes])
 
-  const totalNotes = useMemo(
+  const totalPositionNotes = useMemo(
     () => sections.reduce((sum, s) => sum + s.notes.length, 0),
     [sections],
   )
@@ -66,71 +275,110 @@ export function NotesPanel({ open, onClose }: Props) {
       </div>
 
       {/* Body */}
-      <div className="flex-1 overflow-y-auto px-3 py-3 space-y-3">
-        {totalNotes === 0 ? (
+      <div className="flex-1 overflow-y-auto px-3 py-3 space-y-4">
+        {/* Pinned: Storylet notes ----------------------------------------- */}
+        {storyletNotesSections.active && (
+          <section
+            data-testid="storylet-notes-section"
+            className="space-y-3"
+          >
+            <div className="text-[10px] uppercase tracking-wider text-gray-500 font-semibold">
+              Storylet notes
+            </div>
+            <StoryletNotesGroup
+              storylet={storyletNotesSections.active.storylet}
+              notes={storyletNotesSections.active.notes}
+            />
+            {storyletNotesSections.others.length > 0 && (
+              <div
+                data-testid="storylet-notes-others"
+                className="pt-2 border-t border-gray-800 space-y-3"
+              >
+                {storyletNotesSections.others.map((s) => (
+                  <StoryletNotesGroup
+                    key={s.storylet.id}
+                    storylet={s.storylet}
+                    notes={s.notes}
+                  />
+                ))}
+              </div>
+            )}
+          </section>
+        )}
+
+        {/* Position notes ------------------------------------------------- */}
+        {totalPositionNotes > 0 && (
+          <section className="space-y-2">
+            <div className="text-[10px] uppercase tracking-wider text-gray-500 font-semibold">
+              Position notes
+            </div>
+            {sections.map((section) => (
+              <div
+                key={section.storylet.id}
+                data-testid={`notes-panel-section-${section.storylet.id}`}
+                className="border border-gray-800 rounded overflow-hidden"
+              >
+                <div className="px-2 py-1.5 bg-gray-800/60 text-[11px] uppercase tracking-wide text-gray-400">
+                  {section.storylet.name}
+                </div>
+                <ul className="divide-y divide-gray-800/60">
+                  {section.notes.map(({ id, note }) => {
+                    const body = note?.body ?? ''
+                    const preview = previewBody(body)
+                    const isEmpty = preview.length === 0
+                    const tags = note?.tags ?? []
+                    const color = note?.color ?? '#6b7280'
+                    return (
+                      <li
+                        key={id}
+                        data-testid="notes-panel-note-row"
+                        data-note-id={id}
+                        className="flex items-start gap-2 px-2 py-2"
+                      >
+                        <span
+                          className="w-2.5 h-2.5 rounded-sm shrink-0 translate-y-[3px]"
+                          style={{ backgroundColor: color }}
+                          title={note?.color ? `Color ${note.color}` : 'No color'}
+                        />
+                        <div className="flex-1 min-w-0 space-y-1">
+                          <div
+                            className={`text-[12px] leading-snug truncate ${
+                              isEmpty ? 'text-gray-600 italic' : 'text-gray-200'
+                            }`}
+                            title={isEmpty ? '' : body}
+                          >
+                            {isEmpty ? '(empty)' : preview}
+                          </div>
+                          {tags.length > 0 && (
+                            <div className="flex flex-wrap gap-1">
+                              {tags.map((t) => (
+                                <span
+                                  key={t}
+                                  className="text-[10px] px-1.5 py-0.5 rounded bg-gray-800 text-gray-400 border border-gray-700"
+                                >
+                                  {t}
+                                </span>
+                              ))}
+                            </div>
+                          )}
+                        </div>
+                      </li>
+                    )
+                  })}
+                </ul>
+              </div>
+            ))}
+          </section>
+        )}
+
+        {/* Empty state — only when there is no book at all. */}
+        {!book && (
           <div
             data-testid="notes-panel-empty"
             className="text-center text-xs text-gray-500 py-8"
           >
             No notes yet.
           </div>
-        ) : (
-          sections.map((section) => (
-            <div
-              key={section.storylet.id}
-              data-testid={`notes-panel-section-${section.storylet.id}`}
-              className="border border-gray-800 rounded overflow-hidden"
-            >
-              <div className="px-2 py-1.5 bg-gray-800/60 text-[11px] uppercase tracking-wide text-gray-400">
-                {section.storylet.name}
-              </div>
-              <ul className="divide-y divide-gray-800/60">
-                {section.notes.map(({ id, note }) => {
-                  const body = note?.body ?? ''
-                  const preview = previewBody(body)
-                  const isEmpty = preview.length === 0
-                  const tags = note?.tags ?? []
-                  const color = note?.color ?? '#6b7280'
-                  return (
-                    <li
-                      key={id}
-                      data-testid="notes-panel-note-row"
-                      data-note-id={id}
-                      className="flex items-start gap-2 px-2 py-2"
-                    >
-                      <span
-                        className="w-2.5 h-2.5 rounded-sm shrink-0 translate-y-[3px]"
-                        style={{ backgroundColor: color }}
-                        title={note?.color ? `Color ${note.color}` : 'No color'}
-                      />
-                      <div className="flex-1 min-w-0 space-y-1">
-                        <div
-                          className={`text-[12px] leading-snug truncate ${
-                            isEmpty ? 'text-gray-600 italic' : 'text-gray-200'
-                          }`}
-                          title={isEmpty ? '' : body}
-                        >
-                          {isEmpty ? '(empty)' : preview}
-                        </div>
-                        {tags.length > 0 && (
-                          <div className="flex flex-wrap gap-1">
-                            {tags.map((t) => (
-                              <span
-                                key={t}
-                                className="text-[10px] px-1.5 py-0.5 rounded bg-gray-800 text-gray-400 border border-gray-700"
-                              >
-                                {t}
-                              </span>
-                            ))}
-                          </div>
-                        )}
-                      </div>
-                    </li>
-                  )
-                })}
-              </ul>
-            </div>
-          ))
         )}
       </div>
     </div>

--- a/src/components/notes/NotesPanel.tsx
+++ b/src/components/notes/NotesPanel.tsx
@@ -21,6 +21,8 @@ interface Props {
   focusedNoteId: string | null
   onFocusHandled: () => void
   onEditNote: (noteId: string) => void
+  /** When true, render only the inner body — skip outer wrapper and header. */
+  embedded?: boolean
 }
 
 interface StoryletSection {
@@ -282,6 +284,7 @@ export function NotesPanel({
   focusedNoteId,
   onFocusHandled,
   onEditNote,
+  embedded = false,
 }: Props) {
   const book = useStoryletStore((s) => s.book)
   const activeStoryletId = useStoryletStore((s) => s.activeStoryletId)
@@ -530,22 +533,8 @@ export function NotesPanel({
 
   if (!open) return null
 
-  return (
-    <div
-      data-testid="notes-panel"
-      className="flex flex-col bg-gray-900 border-l border-gray-700 h-full w-[320px] shrink-0 overflow-hidden"
-    >
-      {/* Header */}
-      <div className="flex items-center justify-between px-4 py-3 border-b border-gray-700">
-        <span className="text-sm font-medium text-gray-200">Notes</span>
-        <button
-          onClick={onClose}
-          className="text-gray-500 hover:text-gray-300 text-xs"
-        >
-          Close
-        </button>
-      </div>
-
+  const body = (
+    <>
       {/* Issues section (collapsible) */}
       <div
         data-testid="notes-panel-issues"
@@ -849,6 +838,33 @@ export function NotesPanel({
           </div>
         )}
       </div>
+    </>
+  )
+
+  if (embedded) {
+    return (
+      <div data-testid="notes-panel" className="flex flex-col h-full overflow-hidden">
+        {body}
+      </div>
+    )
+  }
+
+  return (
+    <div
+      data-testid="notes-panel"
+      className="flex flex-col bg-gray-900 border-l border-gray-700 h-full w-[320px] shrink-0 overflow-hidden"
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 py-3 border-b border-gray-700">
+        <span className="text-sm font-medium text-gray-200">Notes</span>
+        <button
+          onClick={onClose}
+          className="text-gray-500 hover:text-gray-300 text-xs"
+        >
+          Close
+        </button>
+      </div>
+      {body}
     </div>
   )
 }

--- a/src/components/notes/NotesPanel.tsx
+++ b/src/components/notes/NotesPanel.tsx
@@ -1,10 +1,16 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { CornerDownRight, Pencil, Trash2 } from 'lucide-react'
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
+import { AlertTriangle, ChevronDown, ChevronRight, CornerDownRight, Pencil, Trash2 } from 'lucide-react'
 import type { EditorView } from '@codemirror/view'
 import { useNotesStore } from '../../stores/notesStore'
 import { useStoryletStore } from '../../stores/storyletStore'
-import { extractNotes } from '../../lib/noteUtils'
-import type { PositionNote, Storylet, StoryletNote } from '../../types'
+import { extractNotes, insertNoteMarker, removeNoteMarker } from '../../lib/noteUtils'
+import { checkNoteConsistency } from '../../lib/noteConsistency'
+import type {
+  NoteConsistencyIssue,
+  PositionNote,
+  Storylet,
+  StoryletNote,
+} from '../../types'
 import { TagChipInput } from './TagChipInput'
 import { ColorPickerPopover } from './ColorPickerPopover'
 
@@ -282,10 +288,21 @@ export function NotesPanel({
   const setActiveStorylet = useStoryletStore((s) => s.setActiveStorylet)
   const positionNotes = useNotesStore((s) => s.positionNotes)
   const storyletNotes = useNotesStore((s) => s.storyletNotes)
+  const addPositionNote = useNotesStore((s) => s.addPositionNote)
+  const removePositionNote = useNotesStore((s) => s.removePositionNote)
+  const removeAllNotesForStorylet = useNotesStore(
+    (s) => s.removeAllNotesForStorylet,
+  )
   const rowRefs = useRef<Map<string, HTMLLIElement>>(new Map())
 
   // Tag filter — chips with AND semantics across all note kinds.
   const [filterTags, setFilterTags] = useState<string[]>([])
+
+  // Issues section: default collapsed, but auto-expand once when the panel
+  // first opens with orphans to surface. `autoExpanded` latches after the
+  // first auto-expand so the user can re-collapse without us re-expanding.
+  const [issuesExpanded, setIssuesExpanded] = useState(false)
+  const [autoExpanded, setAutoExpanded] = useState(false)
 
   // Jump from a panel row to the anchor in the editor. Mirrors
   // CharacterPanel.jumpToMarker but uses the notesStore / noteUtils pattern.
@@ -321,6 +338,120 @@ export function NotesPanel({
       }
     },
     [book, activeStoryletId, editorView, setActiveStorylet],
+  )
+
+  // -------------------------------------------------------------------------
+  // Issues (orphan detection) — recomputes when book or notes state changes.
+  // -------------------------------------------------------------------------
+  const issues = useMemo<NoteConsistencyIssue[]>(
+    () => checkNoteConsistency(book, { positionNotes, storyletNotes }),
+    [book, positionNotes, storyletNotes],
+  )
+  const issueCount = issues.length
+
+  // First time the panel opens while issues exist, auto-expand. `autoExpanded`
+  // latches after the first trigger so the user's subsequent collapse sticks.
+  // Uses the "derived state during render" pattern (same as StoryletNoteRow's
+  // lastSyncedUpdatedAt reconcile) to avoid react-hooks/set-state-in-effect.
+  if (open && issueCount > 0 && !autoExpanded) {
+    setAutoExpanded(true)
+    if (!issuesExpanded) setIssuesExpanded(true)
+  }
+
+  // Resolve handlers -------------------------------------------------------
+
+  /** Delete the store entry for an orphanNote (anchor is missing, user wants
+   *  to abandon the stub). */
+  const handleDeleteOrphanNoteEntry = useCallback(
+    (noteId: string) => {
+      removePositionNote(noteId)
+    },
+    [removePositionNote],
+  )
+
+  /** Insert an anchor for an orphanNote at the current editor cursor on the
+   *  active storylet. */
+  const handleInsertAnchorForOrphan = useCallback(
+    (noteId: string) => {
+      const view = editorView
+      if (!view || !book) return
+      const targetStoryletId = activeStoryletId ?? book.storylets[0]?.id
+      if (!targetStoryletId) return
+      const doInsert = () => {
+        const v = editorView
+        if (!v) return
+        const pos = v.state.selection.main.head
+        const marker = `<!-- note:${noteId} -->`
+        v.dispatch({
+          changes: { from: pos, to: pos, insert: marker },
+          selection: { anchor: pos + marker.length },
+          scrollIntoView: true,
+        })
+        v.focus()
+      }
+      if (targetStoryletId !== activeStoryletId) {
+        setActiveStorylet(targetStoryletId)
+        setTimeout(doInsert, 30)
+      } else {
+        doInsert()
+      }
+    },
+    [editorView, book, activeStoryletId, setActiveStorylet],
+  )
+
+  /** Remove the `<!-- note:<id> -->` anchor from the storylet that owns it
+   *  (inverseOrphanNote). Mirrors CharacterPanel.onRemoveOrphanFromText —
+   *  switches to that storylet first if it isn't already active, then
+   *  dispatches the deletion through the editor so undo history stays intact. */
+  const handleRemoveAnchorFromText = useCallback(
+    (noteId: string, storyletId: string) => {
+      if (!book) return
+      const storylet = book.storylets.find((s) => s.id === storyletId)
+      if (!storylet) return
+      const content = storylet.content ?? ''
+      const escaped = noteId.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+      const re = new RegExp(`<!--\\s*note:${escaped}\\s*-->`)
+      const match = content.match(re)
+      if (!match || typeof match.index !== 'number') return
+      const doRemove = () => {
+        const v = editorView
+        if (!v) return
+        v.dispatch({
+          changes: {
+            from: match.index as number,
+            to: (match.index as number) + match[0].length,
+            insert: '',
+          },
+        })
+      }
+      if (storyletId === activeStoryletId) {
+        doRemove()
+      } else {
+        setActiveStorylet(storyletId)
+        setTimeout(doRemove, 30)
+      }
+      // Silence unused-imports lint — these helpers are surfaced on the panel
+      // for future resolve-action expansion without needing a new import.
+      void insertNoteMarker
+      void removeNoteMarker
+    },
+    [book, activeStoryletId, editorView, setActiveStorylet],
+  )
+
+  /** Create an empty store entry so an orphaned anchor has metadata. */
+  const handleCreateEntryForOrphan = useCallback(
+    (noteId: string) => {
+      addPositionNote(noteId, { body: '' })
+    },
+    [addPositionNote],
+  )
+
+  /** Drop all storylet-notes keyed to a deleted storylet. */
+  const handleDeleteOrphanStoryletNotes = useCallback(
+    (storyletId: string) => {
+      removeAllNotesForStorylet(storyletId)
+    },
+    [removeAllNotesForStorylet],
   )
 
   // Flash + scroll into view when a row becomes focused.
@@ -413,6 +544,135 @@ export function NotesPanel({
         >
           Close
         </button>
+      </div>
+
+      {/* Issues section (collapsible) */}
+      <div
+        data-testid="notes-panel-issues"
+        className="border-b border-gray-800"
+      >
+        <button
+          data-testid="notes-panel-issues-toggle"
+          onClick={() => setIssuesExpanded((v) => !v)}
+          className={`w-full flex items-center gap-1.5 px-3 py-2 text-[11px] transition-colors ${
+            issueCount > 0
+              ? 'text-amber-300 hover:bg-gray-800/60'
+              : 'text-gray-500 hover:bg-gray-800/40'
+          }`}
+        >
+          {issuesExpanded ? (
+            <ChevronDown size={12} />
+          ) : (
+            <ChevronRight size={12} />
+          )}
+          <AlertTriangle size={12} />
+          <span className="uppercase tracking-wider font-semibold">Issues</span>
+          {issueCount > 0 && (
+            <span
+              data-testid="notes-panel-issues-badge"
+              className="ml-auto inline-flex items-center justify-center min-w-[16px] h-4 px-1 rounded-full bg-amber-500/80 text-[9px] text-gray-900 font-semibold tabular-nums"
+            >
+              {issueCount}
+            </span>
+          )}
+          {issueCount === 0 && (
+            <span className="ml-auto text-gray-600 text-[10px]">all clear</span>
+          )}
+        </button>
+        {issuesExpanded && (
+          <div className="px-3 pb-3 pt-0">
+            {issueCount === 0 ? (
+              <div
+                data-testid="notes-panel-issues-empty"
+                className="text-[11px] text-gray-500 italic px-1 py-2"
+              >
+                No orphan notes detected.
+              </div>
+            ) : (
+              <ul className="space-y-1.5">
+                {issues.map((issue, i) => (
+                  <li
+                    key={`${issue.kind}-${i}-${issue.id ?? issue.storyletId ?? ''}`}
+                    data-testid={`notes-panel-issue-${issue.kind}`}
+                    data-issue-kind={issue.kind}
+                    className="text-[11px] text-gray-300 border border-gray-800 rounded px-2 py-1.5 space-y-1"
+                  >
+                    {issue.kind === 'orphanNote' && (
+                      <>
+                        <div>
+                          <span className="text-gray-500">Store entry </span>
+                          <code className="text-gray-400">
+                            {issue.id.slice(0, 8)}
+                            {issue.id.length > 8 ? '\u2026' : ''}
+                          </code>
+                          <span className="text-gray-500"> has no anchor in any storylet.</span>
+                        </div>
+                        <div className="flex gap-1.5 flex-wrap">
+                          <IssueButton
+                            onClick={() => handleDeleteOrphanNoteEntry(issue.id)}
+                          >
+                            Delete entry
+                          </IssueButton>
+                          <IssueButton
+                            onClick={() => handleInsertAnchorForOrphan(issue.id)}
+                          >
+                            Insert anchor at cursor
+                          </IssueButton>
+                        </div>
+                      </>
+                    )}
+                    {issue.kind === 'inverseOrphanNote' && (
+                      <>
+                        <div>
+                          <span className="text-gray-500">Anchor </span>
+                          <code className="text-gray-400">
+                            {issue.id.slice(0, 8)}
+                            {issue.id.length > 8 ? '\u2026' : ''}
+                          </code>
+                          <span className="text-gray-500"> in text has no store entry.</span>
+                        </div>
+                        <div className="flex gap-1.5 flex-wrap">
+                          <IssueButton
+                            onClick={() =>
+                              handleRemoveAnchorFromText(issue.id, issue.storyletId)
+                            }
+                          >
+                            Remove from text
+                          </IssueButton>
+                          <IssueButton
+                            onClick={() => handleCreateEntryForOrphan(issue.id)}
+                          >
+                            Create empty entry
+                          </IssueButton>
+                        </div>
+                      </>
+                    )}
+                    {issue.kind === 'orphanStoryletNote' && (
+                      <>
+                        <div>
+                          <span className="text-gray-500">Storylet notes on deleted storylet </span>
+                          <code className="text-gray-400">
+                            {issue.storyletId.slice(0, 8)}
+                            {issue.storyletId.length > 8 ? '\u2026' : ''}
+                          </code>
+                        </div>
+                        <div className="flex gap-1.5 flex-wrap">
+                          <IssueButton
+                            onClick={() =>
+                              handleDeleteOrphanStoryletNotes(issue.storyletId)
+                            }
+                          >
+                            Delete
+                          </IssueButton>
+                        </div>
+                      </>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        )}
       </div>
 
       {/* Filter bar */}
@@ -590,5 +850,26 @@ export function NotesPanel({
         )}
       </div>
     </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// IssueButton — compact action pill used inside the Issues section.
+// ---------------------------------------------------------------------------
+
+function IssueButton({
+  onClick,
+  children,
+}: {
+  onClick: () => void
+  children: ReactNode
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className="px-2 py-0.5 text-[10px] text-gray-300 border border-gray-700 hover:border-gray-500 hover:bg-gray-800 rounded transition-colors"
+    >
+      {children}
+    </button>
   )
 }

--- a/src/components/notes/NotesPanel.tsx
+++ b/src/components/notes/NotesPanel.tsx
@@ -1,0 +1,138 @@
+import { useMemo } from 'react'
+import { useNotesStore } from '../../stores/notesStore'
+import { useStoryletStore } from '../../stores/storyletStore'
+import { extractNotes } from '../../lib/noteUtils'
+import type { PositionNote, Storylet } from '../../types'
+
+interface Props {
+  open: boolean
+  onClose: () => void
+}
+
+interface StoryletSection {
+  storylet: Storylet
+  notes: Array<{ id: string; offset: number; note: PositionNote | undefined }>
+}
+
+function previewBody(body: string): string {
+  const collapsed = body.replace(/\s+/g, ' ').trim()
+  if (collapsed.length <= 60) return collapsed
+  return collapsed.slice(0, 60).trimEnd() + '\u2026'
+}
+
+export function NotesPanel({ open, onClose }: Props) {
+  const book = useStoryletStore((s) => s.book)
+  const positionNotes = useNotesStore((s) => s.positionNotes)
+
+  const sections = useMemo<StoryletSection[]>(() => {
+    if (!book) return []
+    const out: StoryletSection[] = []
+    for (const storylet of book.storylets) {
+      const extracted = extractNotes(storylet.content ?? '')
+      if (extracted.length === 0) continue
+      out.push({
+        storylet,
+        notes: extracted.map((n) => ({
+          id: n.id,
+          offset: n.offset,
+          note: positionNotes[n.id],
+        })),
+      })
+    }
+    return out
+  }, [book, positionNotes])
+
+  const totalNotes = useMemo(
+    () => sections.reduce((sum, s) => sum + s.notes.length, 0),
+    [sections],
+  )
+
+  if (!open) return null
+
+  return (
+    <div
+      data-testid="notes-panel"
+      className="flex flex-col bg-gray-900 border-l border-gray-700 h-full w-[320px] shrink-0 overflow-hidden"
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 py-3 border-b border-gray-700">
+        <span className="text-sm font-medium text-gray-200">Notes</span>
+        <button
+          onClick={onClose}
+          className="text-gray-500 hover:text-gray-300 text-xs"
+        >
+          Close
+        </button>
+      </div>
+
+      {/* Body */}
+      <div className="flex-1 overflow-y-auto px-3 py-3 space-y-3">
+        {totalNotes === 0 ? (
+          <div
+            data-testid="notes-panel-empty"
+            className="text-center text-xs text-gray-500 py-8"
+          >
+            No notes yet.
+          </div>
+        ) : (
+          sections.map((section) => (
+            <div
+              key={section.storylet.id}
+              data-testid={`notes-panel-section-${section.storylet.id}`}
+              className="border border-gray-800 rounded overflow-hidden"
+            >
+              <div className="px-2 py-1.5 bg-gray-800/60 text-[11px] uppercase tracking-wide text-gray-400">
+                {section.storylet.name}
+              </div>
+              <ul className="divide-y divide-gray-800/60">
+                {section.notes.map(({ id, note }) => {
+                  const body = note?.body ?? ''
+                  const preview = previewBody(body)
+                  const isEmpty = preview.length === 0
+                  const tags = note?.tags ?? []
+                  const color = note?.color ?? '#6b7280'
+                  return (
+                    <li
+                      key={id}
+                      data-testid="notes-panel-note-row"
+                      data-note-id={id}
+                      className="flex items-start gap-2 px-2 py-2"
+                    >
+                      <span
+                        className="w-2.5 h-2.5 rounded-sm shrink-0 translate-y-[3px]"
+                        style={{ backgroundColor: color }}
+                        title={note?.color ? `Color ${note.color}` : 'No color'}
+                      />
+                      <div className="flex-1 min-w-0 space-y-1">
+                        <div
+                          className={`text-[12px] leading-snug truncate ${
+                            isEmpty ? 'text-gray-600 italic' : 'text-gray-200'
+                          }`}
+                          title={isEmpty ? '' : body}
+                        >
+                          {isEmpty ? '(empty)' : preview}
+                        </div>
+                        {tags.length > 0 && (
+                          <div className="flex flex-wrap gap-1">
+                            {tags.map((t) => (
+                              <span
+                                key={t}
+                                className="text-[10px] px-1.5 py-0.5 rounded bg-gray-800 text-gray-400 border border-gray-700"
+                              >
+                                {t}
+                              </span>
+                            ))}
+                          </div>
+                        )}
+                      </div>
+                    </li>
+                  )
+                })}
+              </ul>
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/notes/TagChipInput.tsx
+++ b/src/components/notes/TagChipInput.tsx
@@ -1,0 +1,120 @@
+import { useState, useCallback } from 'react'
+import type { KeyboardEvent } from 'react'
+import { X } from 'lucide-react'
+
+interface Props {
+  tags: string[]
+  onChange: (tags: string[]) => void
+  placeholder?: string
+  /** Visual density — 'sm' for compact inline rows, 'md' default for modal. */
+  size?: 'sm' | 'md'
+  /** Optional data-testid prefix for the input + chips. */
+  testId?: string
+}
+
+function normalizeTag(raw: string): string {
+  return raw.trim().replace(/\s+/g, ' ')
+}
+
+/**
+ * Simple chip-input for free-form string tags.
+ * - Enter or comma commits the current draft as a new chip.
+ * - Backspace on empty input removes the last chip.
+ * - Clicking the X on a chip removes it.
+ * - Duplicates are silently rejected.
+ */
+export function TagChipInput({
+  tags,
+  onChange,
+  placeholder = 'Add tag…',
+  size = 'md',
+  testId,
+}: Props) {
+  const [draft, setDraft] = useState('')
+
+  const commit = useCallback(
+    (value: string) => {
+      const tag = normalizeTag(value)
+      if (!tag) return
+      if (tags.includes(tag)) {
+        setDraft('')
+        return
+      }
+      onChange([...tags, tag])
+      setDraft('')
+    },
+    [tags, onChange],
+  )
+
+  const removeAt = useCallback(
+    (idx: number) => {
+      const next = tags.slice()
+      next.splice(idx, 1)
+      onChange(next)
+    },
+    [tags, onChange],
+  )
+
+  const onKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'Enter' || e.key === ',') {
+        e.preventDefault()
+        commit(draft)
+        return
+      }
+      if (e.key === 'Backspace' && draft.length === 0 && tags.length > 0) {
+        e.preventDefault()
+        removeAt(tags.length - 1)
+      }
+    },
+    [draft, tags, commit, removeAt],
+  )
+
+  const chipClass =
+    size === 'sm'
+      ? 'inline-flex items-center gap-0.5 text-[10px] px-1.5 py-0.5 rounded bg-gray-700 text-gray-200 border border-gray-600'
+      : 'inline-flex items-center gap-1 text-[11px] px-2 py-0.5 rounded bg-gray-700 text-gray-200 border border-gray-600'
+  const inputClass =
+    size === 'sm'
+      ? 'flex-1 min-w-[60px] bg-transparent text-[11px] text-gray-200 placeholder:text-gray-600 outline-none px-1 py-0.5'
+      : 'flex-1 min-w-[80px] bg-transparent text-xs text-gray-200 placeholder:text-gray-600 outline-none px-1 py-1'
+  const wrapperClass =
+    size === 'sm'
+      ? 'flex flex-wrap items-center gap-1 bg-gray-800/60 border border-gray-700 rounded px-1 py-0.5'
+      : 'flex flex-wrap items-center gap-1 bg-gray-800 border border-gray-700 rounded px-1.5 py-1'
+
+  return (
+    <div
+      className={wrapperClass}
+      data-testid={testId ? `${testId}-wrapper` : undefined}
+    >
+      {tags.map((tag, idx) => (
+        <span
+          key={`${tag}-${idx}`}
+          className={chipClass}
+          data-testid={testId ? `${testId}-chip` : undefined}
+        >
+          <span className="truncate max-w-[120px]">{tag}</span>
+          <button
+            type="button"
+            onClick={() => removeAt(idx)}
+            className="text-gray-400 hover:text-red-300 shrink-0"
+            aria-label={`Remove tag ${tag}`}
+            data-testid={testId ? `${testId}-chip-remove` : undefined}
+          >
+            <X size={size === 'sm' ? 10 : 12} />
+          </button>
+        </span>
+      ))}
+      <input
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        onKeyDown={onKeyDown}
+        onBlur={() => commit(draft)}
+        placeholder={placeholder}
+        className={inputClass}
+        data-testid={testId}
+      />
+    </div>
+  )
+}

--- a/src/lib/export.ts
+++ b/src/lib/export.ts
@@ -20,6 +20,7 @@ import {
   STAT_MARKER_REGEX,
   STATBLOCK_MARKER_REGEX,
 } from './markerUtils'
+import { NOTE_MARKER_REGEX } from './noteUtils'
 import { renderStoryletAsMarkdown, renderStoryletAsHtml } from './render'
 
 // ─── Helpers ────────────────────────────────────────────
@@ -332,7 +333,7 @@ export function processCharacterMarkers(
   content: string,
   ctx: CharacterMarkerContext,
   format: StatblockExportFormat,
-  options?: { preserveStatMarkers?: boolean }
+  options?: { preserveStatMarkers?: boolean; preserveNoteMarkers?: boolean }
 ): string {
   if (!content) return content
   let out = content
@@ -340,6 +341,12 @@ export function processCharacterMarkers(
   // 1) Strip stat-delta markers (unless MD preserve flag is set).
   if (!options?.preserveStatMarkers) {
     out = out.replace(new RegExp(STAT_MARKER_REGEX.source, 'g'), '')
+  }
+
+  // 1b) Strip note anchors (unless MD preserve flag is set). Notes never
+  // appear in rendered output — they're metadata-only pointers for the panel.
+  if (!options?.preserveNoteMarkers) {
+    out = out.replace(new RegExp(NOTE_MARKER_REGEX.source, 'g'), '')
   }
 
   // 2) Replace statblock markers with rendered blocks.
@@ -503,7 +510,7 @@ export function getDepth(storylet: Storylet, storylets: Storylet[]): number {
 /** Get the full book as a single markdown string with storylet headings */
 function bookToMarkdown(
   book: Book,
-  options?: { preserveStatMarkers?: boolean }
+  options?: { preserveStatMarkers?: boolean; preserveNoteMarkers?: boolean }
 ): string {
   const parts: string[] = [`# ${book.title}\n`]
   for (const doc of book.storylets) {
@@ -540,7 +547,7 @@ function hasStringValue(node: unknown): node is { value: string } {
 
 export function exportAsMarkdown(
   book: Book,
-  options?: { preserveStatMarkers?: boolean }
+  options?: { preserveStatMarkers?: boolean; preserveNoteMarkers?: boolean }
 ): void {
   download(
     bookToMarkdown(book, options),
@@ -552,7 +559,7 @@ export function exportAsMarkdown(
 /** In-memory variant: returns the Markdown string instead of triggering a download. */
 export function renderBookAsMarkdown(
   book: Book,
-  options?: { preserveStatMarkers?: boolean }
+  options?: { preserveStatMarkers?: boolean; preserveNoteMarkers?: boolean }
 ): string {
   return bookToMarkdown(book, options)
 }

--- a/src/lib/fileSystem.ts
+++ b/src/lib/fileSystem.ts
@@ -10,6 +10,7 @@ import { serializePlayer, hydratePlayer } from '../stores/playerStore'
 import { serializeImageReveal, hydrateImageReveal } from '../stores/imageRevealStore'
 import { serializeWriteathon, hydrateWriteathon } from '../stores/writeathonStore'
 import { serializeMetrics, hydrateMetrics } from '../stores/metricsStore'
+import { serializeNotes, hydrateNotes } from '../stores/notesStore'
 
 // ---------------------------------------------------------------------------
 // Section registry — add/remove cross-store sections here
@@ -27,11 +28,13 @@ const EXTERNAL_SECTIONS: [
   FileSection<'quests'>,
   FileSection<'writeathon'>,
   FileSection<'metrics'>,
+  FileSection<'notes'>,
 ] = [
   { key: 'player',     serialize: serializePlayer,     hydrate: hydratePlayer },
   { key: 'quests',     serialize: serializeImageReveal, hydrate: hydrateImageReveal },
   { key: 'writeathon', serialize: serializeWriteathon,  hydrate: hydrateWriteathon },
   { key: 'metrics',    serialize: serializeMetrics,     hydrate: hydrateMetrics },
+  { key: 'notes',      serialize: serializeNotes,       hydrate: hydrateNotes },
 ]
 
 // queryPermission is not yet in TypeScript lib types for File System Access API
@@ -123,7 +126,7 @@ export async function buildWritinatorFile(
   const publishedSnapshots = await getAllPublishedSnapshots()
   const { characters, markers } = useCharacterStore.getState()
   const file: WritinatorFile = {
-    version: 7,
+    version: 8,
     book,
     snapshots,
     publishedSnapshots,

--- a/src/lib/migration.ts
+++ b/src/lib/migration.ts
@@ -7,6 +7,7 @@ import type {
   ImageRevealFileData,
   MetricsFileData,
   NamedStyle,
+  NotesFileData,
   PlayerFileData,
   PublishedSnapshot,
   Snapshot,
@@ -124,9 +125,10 @@ function v3BookToV4(book: LegacyV3Book): Book {
   }
 }
 
-type V4File = Omit<WritinatorFile, 'version' | 'publishedSnapshots' | 'saveCounter' | 'player' | 'quests' | 'writeathon' | 'metrics'> & { version: 4 }
-type V5File = Omit<WritinatorFile, 'version' | 'saveCounter' | 'player' | 'quests' | 'writeathon' | 'metrics'> & { version: 5 }
-type V6File = Omit<WritinatorFile, 'version'> & { version: 6 }
+type V4File = Omit<WritinatorFile, 'version' | 'publishedSnapshots' | 'saveCounter' | 'player' | 'quests' | 'writeathon' | 'metrics' | 'notes'> & { version: 4 }
+type V5File = Omit<WritinatorFile, 'version' | 'saveCounter' | 'player' | 'quests' | 'writeathon' | 'metrics' | 'notes'> & { version: 5 }
+type V6File = Omit<WritinatorFile, 'version' | 'notes'> & { version: 6 }
+type V7File = Omit<WritinatorFile, 'version' | 'notes'> & { version: 7 }
 
 function migrateOldBook(old: OldBook): V4File {
   const storylets: Storylet[] = old.chapters.map((ch) => ({
@@ -208,7 +210,7 @@ function isV7File(data: Record<string, unknown>): boolean {
   )
 }
 
-function migrateToV7(v6: V6File): WritinatorFile {
+function migrateToV7(v6: V6File): V7File {
   return {
     version: 7,
     book: v6.book,
@@ -222,34 +224,64 @@ function migrateToV7(v6: V6File): WritinatorFile {
   }
 }
 
+function isV8File(data: Record<string, unknown>): boolean {
+  return (
+    data.version === 8 &&
+    typeof data.saveCounter === 'number' &&
+    isRecord(data.book) &&
+    typeof (data.book as Record<string, unknown>).id === 'string' &&
+    typeof (data.book as Record<string, unknown>).title === 'string' &&
+    Array.isArray((data.book as Record<string, unknown>).storylets)
+  )
+}
+
+function migrateToV8(v7: V7File): WritinatorFile {
+  return {
+    version: 8,
+    book: v7.book,
+    snapshots: v7.snapshots,
+    publishedSnapshots: v7.publishedSnapshots,
+    globalSettings: v7.globalSettings,
+    characters: v7.characters,
+    markers: v7.markers,
+    saveCounter: v7.saveCounter,
+    player: v7.player,
+    quests: v7.quests,
+    writeathon: v7.writeathon,
+    metrics: v7.metrics,
+    // notes absent → hydrate no-op on load, preserving localforage state
+  }
+}
+
 /**
  * Extract cross-store sections from a raw parsed file object.
  * Returns undefined for each absent/invalid section to allow hydrate no-ops.
  */
-function extractExternalSections(data: Record<string, unknown>): Pick<WritinatorFile, 'player' | 'quests' | 'writeathon' | 'metrics'> {
+function extractExternalSections(data: Record<string, unknown>): Pick<WritinatorFile, 'player' | 'quests' | 'writeathon' | 'metrics' | 'notes'> {
   return {
     player: isRecord(data.player) ? (data.player as unknown as PlayerFileData) : undefined,
     quests: isRecord(data.quests) ? (data.quests as unknown as ImageRevealFileData) : undefined,
     writeathon: isRecord(data.writeathon) ? (data.writeathon as unknown as WriteathonFileData) : undefined,
     metrics: isRecord(data.metrics) ? (data.metrics as unknown as MetricsFileData) : undefined,
+    notes: isRecord(data.notes) ? (data.notes as unknown as NotesFileData) : undefined,
   }
 }
 
 /**
- * Migrate any file data (old/v2/v3/v4/v5/v6/v7+) into a v7 WritinatorFile.
+ * Migrate any file data (old/v2/v3/v4/v5/v6/v7/v8+) into a v8 WritinatorFile.
  */
 export function migrateFile(data: unknown): WritinatorFile {
   if (!isRecord(data)) {
     throw new Error('Invalid file: expected a JSON object')
   }
 
-  // v7 — already current (or future: permissive on version > 7)
-  if (isV7File(data) || (typeof data.version === 'number' && data.version > 7)) {
-    if (typeof data.version === 'number' && data.version > 7) {
-      console.warn(`[migrateFile] file version ${data.version} is newer than expected (7); attempting to load`)
+  // v8 — already current (or future: permissive on version > 8)
+  if (isV8File(data) || (typeof data.version === 'number' && data.version > 8)) {
+    if (typeof data.version === 'number' && data.version > 8) {
+      console.warn(`[migrateFile] file version ${data.version} is newer than expected (8); attempting to load`)
     }
     return {
-      version: 7,
+      version: 8,
       book: data.book as Book,
       snapshots: (data.snapshots ?? {}) as Record<string, Snapshot[]>,
       publishedSnapshots: (data.publishedSnapshots ?? {}) as Record<string, PublishedSnapshot[]>,
@@ -261,7 +293,26 @@ export function migrateFile(data: unknown): WritinatorFile {
     }
   }
 
-  // v6 → v7: promote to v7 (cross-store sections absent = hydrate no-ops)
+  // v7 → v8: promote to v8 (notes section absent = hydrate no-op)
+  if (isV7File(data)) {
+    const v7: V7File = {
+      version: 7,
+      book: data.book as Book,
+      snapshots: (data.snapshots ?? {}) as Record<string, Snapshot[]>,
+      publishedSnapshots: (data.publishedSnapshots ?? {}) as Record<string, PublishedSnapshot[]>,
+      globalSettings: flattenGlobalSettings(data.globalSettings as GlobalSettings | undefined),
+      characters: (data.characters ?? []) as Character[],
+      markers: (data.markers ?? {}) as Record<string, StatDelta[]>,
+      saveCounter: data.saveCounter as number,
+      player: isRecord(data.player) ? (data.player as unknown as PlayerFileData) : undefined,
+      quests: isRecord(data.quests) ? (data.quests as unknown as ImageRevealFileData) : undefined,
+      writeathon: isRecord(data.writeathon) ? (data.writeathon as unknown as WriteathonFileData) : undefined,
+      metrics: isRecord(data.metrics) ? (data.metrics as unknown as MetricsFileData) : undefined,
+    }
+    return migrateToV8(v7)
+  }
+
+  // v6 → v7 → v8: promote to v8 (cross-store sections absent = hydrate no-ops)
   if (isV6File(data)) {
     const v6: V6File = {
       version: 6,
@@ -273,12 +324,12 @@ export function migrateFile(data: unknown): WritinatorFile {
       markers: (data.markers ?? {}) as Record<string, StatDelta[]>,
       saveCounter: data.saveCounter as number,
     }
-    return migrateToV7(v6)
+    return migrateToV8(migrateToV7(v6))
   }
 
-  // v5 → v6 → v7: add saveCounter
+  // v5 → v6 → v7 → v8: add saveCounter
   if (isV5File(data)) {
-    return migrateToV7(migrateToV6({
+    return migrateToV8(migrateToV7(migrateToV6({
       version: 5,
       book: data.book as Book,
       snapshots: (data.snapshots ?? {}) as Record<string, Snapshot[]>,
@@ -286,51 +337,51 @@ export function migrateFile(data: unknown): WritinatorFile {
       globalSettings: flattenGlobalSettings(data.globalSettings as GlobalSettings | undefined),
       characters: (data.characters ?? []) as Character[],
       markers: (data.markers ?? {}) as Record<string, StatDelta[]>,
-    }))
+    })))
   }
 
-  // v4 → v5 → v6 → v7: add publishedSnapshots + saveCounter
+  // v4 → v5 → v6 → v7 → v8: add publishedSnapshots + saveCounter
   if (isV4File(data)) {
-    return migrateToV7(migrateToV6(migrateToV5({
+    return migrateToV8(migrateToV7(migrateToV6(migrateToV5({
       version: 4,
       book: data.book as Book,
       snapshots: (data.snapshots ?? {}) as Record<string, Snapshot[]>,
       globalSettings: flattenGlobalSettings(data.globalSettings as GlobalSettings | undefined),
       characters: (data.characters ?? []) as Character[],
       markers: (data.markers ?? {}) as Record<string, StatDelta[]>,
-    })))
+    }))))
   }
 
-  // v3 → v4 → v5 → v6 → v7: rename book.documents → book.storylets
+  // v3 → v4 → v5 → v6 → v7 → v8: rename book.documents → book.storylets
   if (isV3File(data)) {
     const legacyBook = data.book as unknown as LegacyV3Book
-    return migrateToV7(migrateToV6(migrateToV5({
+    return migrateToV8(migrateToV7(migrateToV6(migrateToV5({
       version: 4,
       book: v3BookToV4(legacyBook),
       snapshots: (data.snapshots ?? {}) as Record<string, Snapshot[]>,
       globalSettings: flattenGlobalSettings(data.globalSettings as GlobalSettings | undefined),
       characters: (data.characters ?? []) as Character[],
       markers: (data.markers ?? {}) as Record<string, StatDelta[]>,
-    })))
+    }))))
   }
 
-  // v2 → v4 → v5 → v6 → v7: add empty characters + markers, rename documents → storylets
+  // v2 → v4 → v5 → v6 → v7 → v8: add empty characters + markers, rename documents → storylets
   if (isV2File(data)) {
     const legacyBook = data.book as unknown as LegacyV3Book
-    return migrateToV7(migrateToV6(migrateToV5({
+    return migrateToV8(migrateToV7(migrateToV6(migrateToV5({
       version: 4,
       book: v3BookToV4(legacyBook),
       snapshots: (data.snapshots ?? {}) as Record<string, Snapshot[]>,
       globalSettings: flattenGlobalSettings(data.globalSettings as GlobalSettings | undefined),
       characters: [],
       markers: {},
-    })))
+    }))))
   }
 
-  // Old format: bare Book with chapters → v4 → v5 → v6 → v7
+  // Old format: bare Book with chapters → v4 → v5 → v6 → v7 → v8
   if (isOldFormat(data)) {
     const v4 = migrateOldBook(data as OldBook)
-    return migrateToV7(migrateToV6(migrateToV5(v4)))
+    return migrateToV8(migrateToV7(migrateToV6(migrateToV5(v4))))
   }
 
   throw new Error('Invalid file: unrecognized format')

--- a/src/lib/noteConsistency.ts
+++ b/src/lib/noteConsistency.ts
@@ -1,0 +1,79 @@
+import type {
+  Book,
+  NoteConsistencyIssue,
+  PositionNote,
+  StoryletNote,
+} from '../types'
+import { extractNotes } from './noteUtils'
+
+export interface NotesStoreState {
+  positionNotes: Record<string, PositionNote>
+  storyletNotes: Record<string, StoryletNote[]>
+}
+
+/**
+ * Scan book + notes store for inconsistencies. Pure.
+ *
+ * - `orphanNote`: store has a position-note entry whose id does not appear as
+ *   a `<!-- note:<id> -->` anchor in any storylet's content.
+ * - `inverseOrphanNote`: a storylet's content contains a `<!-- note:<id> -->`
+ *   anchor, but the store has no matching entry.
+ * - `orphanStoryletNote`: the store has storylet-notes keyed to a storyletId
+ *   that is not present in `book.storylets`.
+ */
+export function checkNoteConsistency(
+  book: Book | null,
+  storeState: NotesStoreState,
+): NoteConsistencyIssue[] {
+  const issues: NoteConsistencyIssue[] = []
+  if (!book) return issues
+
+  const storylets = book.storylets ?? []
+
+  // Index every anchor id seen in content. A Set is enough — duplicate anchors
+  // (same id inserted twice) aren't currently possible via the UI.
+  const anchoredIds = new Set<string>()
+  for (const storylet of storylets) {
+    const content = storylet.content ?? ''
+    if (!content) continue
+    for (const { id } of extractNotes(content)) {
+      anchoredIds.add(id)
+    }
+  }
+
+  // orphanNote: store → no anchor.
+  for (const id of Object.keys(storeState.positionNotes)) {
+    if (!anchoredIds.has(id)) {
+      issues.push({ kind: 'orphanNote', id, storyletId: undefined })
+    }
+  }
+
+  // inverseOrphanNote: anchor → no store. We revisit per-storylet so we can
+  // attribute each inverse orphan to its storylet (the panel's "Remove from
+  // text" action needs to know which content to edit).
+  const seenInverse = new Set<string>()
+  for (const storylet of storylets) {
+    const content = storylet.content ?? ''
+    if (!content) continue
+    for (const { id } of extractNotes(content)) {
+      if (storeState.positionNotes[id]) continue
+      if (seenInverse.has(id)) continue
+      seenInverse.add(id)
+      issues.push({ kind: 'inverseOrphanNote', id, storyletId: storylet.id })
+    }
+  }
+
+  // orphanStoryletNote: storylet-notes keyed to a missing storylet.
+  const storyletIds = new Set(storylets.map((s) => s.id))
+  for (const storyletId of Object.keys(storeState.storyletNotes)) {
+    if (!storyletIds.has(storyletId)) {
+      issues.push({
+        kind: 'orphanStoryletNote',
+        id: undefined,
+        storyletId,
+      })
+    }
+  }
+
+  return issues
+}

--- a/src/lib/noteUtils.ts
+++ b/src/lib/noteUtils.ts
@@ -1,0 +1,50 @@
+/**
+ * Matches note anchors of the form `<!-- note:<uuid> -->`.
+ * Id portion allows any alphanumeric run with dashes (UUIDs satisfy this),
+ * mirroring STAT_MARKER_REGEX in markerUtils.ts.
+ */
+export const NOTE_MARKER_REGEX = /<!--\s*note:([A-Za-z0-9-]+)\s*-->/g
+
+export interface ExtractedNote {
+  id: string
+  offset: number
+}
+
+/**
+ * Extract every note anchor in `content` in occurrence order.
+ * `offset` is the byte offset of the anchor's `<` in the content string.
+ */
+export function extractNotes(content: string): ExtractedNote[] {
+  if (!content) return []
+  const results: ExtractedNote[] = []
+
+  // Reset lastIndex defensively (shared global regex).
+  NOTE_MARKER_REGEX.lastIndex = 0
+
+  let m: RegExpExecArray | null
+  while ((m = NOTE_MARKER_REGEX.exec(content)) !== null) {
+    results.push({ id: m[1], offset: m.index })
+  }
+
+  return results
+}
+
+/** Insert a note anchor at `pos` returning the new content. */
+export function insertNoteMarker(content: string, pos: number, id: string): string {
+  const clamped = Math.max(0, Math.min(pos, content.length))
+  const marker = `<!-- note:${id} -->`
+  return content.slice(0, clamped) + marker + content.slice(clamped)
+}
+
+/**
+ * Remove the first note anchor whose identifier matches `id`.
+ */
+export function removeNoteMarker(content: string, id: string): string {
+  const escaped = id.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const re = new RegExp(`<!--\\s*note:${escaped}\\s*-->`)
+  const match = content.match(re)
+  if (match && typeof match.index === 'number') {
+    return content.slice(0, match.index) + content.slice(match.index + match[0].length)
+  }
+  return content
+}

--- a/src/lib/render.ts
+++ b/src/lib/render.ts
@@ -15,7 +15,7 @@ import { parseMarkdown } from './ast'
 export function renderStoryletAsMarkdown(
   storylet: Storylet,
   book: Book,
-  options?: { preserveStatMarkers?: boolean }
+  options?: { preserveStatMarkers?: boolean; preserveNoteMarkers?: boolean }
 ): string {
   const depth = getDepth(storylet, book.storylets)
   const hashes = '#'.repeat(Math.min(depth + 2, 6))

--- a/src/stores/editorStore.ts
+++ b/src/stores/editorStore.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand'
 import { persist, createJSONStorage } from 'zustand/middleware'
 import * as localforage from 'localforage'
-import type { EditorPreferences } from '../types'
+import type { EditorPreferences, RightPanelTab } from '../types'
 
 interface EditorState extends EditorPreferences {
   /** Transient: current CodeMirror main-selection head offset. Not persisted. */
@@ -21,6 +21,7 @@ interface EditorState extends EditorPreferences {
   setCollapsedStoryletIds: (ids: string[]) => void
   setCursorOffset: (offset: number) => void
   pushRecentColor: (color: string) => void
+  setRightPanelActiveTab: (tab: RightPanelTab | null) => void
 }
 
 const RECENT_COLORS_MAX = 8
@@ -51,6 +52,7 @@ export const useEditorStore = create<EditorState>()(
       collapsedStoryletIds: [],
       cursorOffset: 0,
       recentColors: [],
+      rightPanelActiveTab: null,
 
       setVimMode: (enabled: boolean) => set({ vimMode: enabled }),
       toggleVimMode: () => set({ vimMode: !get().vimMode }),
@@ -92,6 +94,8 @@ export const useEditorStore = create<EditorState>()(
         )
         set({ recentColors: next })
       },
+      setRightPanelActiveTab: (tab: RightPanelTab | null) =>
+        set({ rightPanelActiveTab: tab }),
     }),
     {
       name: 'writinator-editor',
@@ -106,6 +110,7 @@ export const useEditorStore = create<EditorState>()(
           sidebarOpen: state.sidebarOpen,
           collapsedStoryletIds: state.collapsedStoryletIds,
           recentColors: state.recentColors,
+          rightPanelActiveTab: state.rightPanelActiveTab,
         }) as unknown as EditorState,
     }
   )

--- a/src/stores/keybindingStore.ts
+++ b/src/stores/keybindingStore.ts
@@ -11,6 +11,7 @@ export type ActionName =
   | 'toggleRenderMode'
   | 'toggleCharacterPanel'
   | 'insertStatMarker'
+  | 'insertNote'
   | 'exportBook'
   | 'findInBook'
   | 'openFile'
@@ -35,6 +36,7 @@ export const ACTION_LABELS: Record<ActionName, string> = {
   toggleRenderMode: 'Cycle Presentation',
   toggleCharacterPanel: 'Toggle Character Panel',
   insertStatMarker: 'Insert stat change',
+  insertNote: 'Insert Note',
   exportBook: 'Export book',
   findInBook: 'Find in book',
   openFile: 'Open file',
@@ -49,6 +51,7 @@ export const DEFAULT_KEYMAP: KeyMap = {
   toggleRenderMode: { key: 'p', ctrl: true, shift: true },
   toggleCharacterPanel: { key: 'c', ctrl: true, shift: true },
   insertStatMarker: { key: '.', ctrl: true, shift: true },
+  insertNote: { key: 'n', ctrl: true, shift: true },
   exportBook: { key: 'e', ctrl: true, shift: true },
   findInBook: { key: 'f', ctrl: true, shift: true },
 }

--- a/src/stores/keybindingStore.ts
+++ b/src/stores/keybindingStore.ts
@@ -10,6 +10,7 @@ export type ActionName =
   | 'snapshotHistory'
   | 'toggleRenderMode'
   | 'toggleCharacterPanel'
+  | 'toggleNotesPanel'
   | 'insertStatMarker'
   | 'insertNote'
   | 'exportBook'
@@ -35,6 +36,7 @@ export const ACTION_LABELS: Record<ActionName, string> = {
   snapshotHistory: 'Snapshot history',
   toggleRenderMode: 'Cycle Presentation',
   toggleCharacterPanel: 'Toggle Character Panel',
+  toggleNotesPanel: 'Toggle Notes Panel',
   insertStatMarker: 'Insert stat change',
   insertNote: 'Insert Note',
   exportBook: 'Export book',
@@ -50,6 +52,7 @@ export const DEFAULT_KEYMAP: KeyMap = {
   snapshotHistory: { key: 'h', ctrl: true, shift: true },
   toggleRenderMode: { key: 'p', ctrl: true, shift: true },
   toggleCharacterPanel: { key: 'c', ctrl: true, shift: true },
+  toggleNotesPanel: { key: 'j', ctrl: true, shift: true },
   insertStatMarker: { key: '.', ctrl: true, shift: true },
   insertNote: { key: 'n', ctrl: true, shift: true },
   exportBook: { key: 'e', ctrl: true, shift: true },

--- a/src/stores/notesStore.ts
+++ b/src/stores/notesStore.ts
@@ -1,0 +1,214 @@
+import { create } from 'zustand'
+import { persist, createJSONStorage } from 'zustand/middleware'
+import * as localforage from 'localforage'
+import type {
+  NotesFileData,
+  PositionNote,
+  StoryletNote,
+} from '../types'
+
+interface NotesState {
+  /** Position notes keyed by note UUID (matching `<!-- note:<uuid> -->`). */
+  positionNotes: Record<string, PositionNote>
+  /** Storylet-level notes keyed by storyletId. Each storylet holds an ordered list. */
+  storyletNotes: Record<string, StoryletNote[]>
+  hasHydrated: boolean
+
+  // Position note CRUD
+  addPositionNote: (
+    id: string,
+    partial: Partial<Omit<PositionNote, 'id' | 'createdAt' | 'updatedAt'>>,
+  ) => void
+  updatePositionNote: (
+    id: string,
+    patch: Partial<Omit<PositionNote, 'id' | 'createdAt'>>,
+  ) => void
+  removePositionNote: (id: string) => void
+
+  // Storylet note CRUD
+  addStoryletNote: (storyletId: string, note: StoryletNote) => void
+  updateStoryletNote: (
+    storyletId: string,
+    noteId: string,
+    patch: Partial<Omit<StoryletNote, 'id' | 'storyletId' | 'createdAt'>>,
+  ) => void
+  removeStoryletNote: (storyletId: string, noteId: string) => void
+  removeAllNotesForStorylet: (storyletId: string) => void
+
+  // Bulk load (for file load)
+  loadFromFile: (data: NotesFileData) => void
+  reset: () => void
+}
+
+function nowIso(): string {
+  return new Date().toISOString()
+}
+
+const localforageStorage = createJSONStorage<NotesState>(() => ({
+  getItem: async (name: string) => {
+    const value = await localforage.getItem<string>(name)
+    return value
+  },
+  setItem: async (name: string, value: string) => {
+    await localforage.setItem(name, value)
+  },
+  removeItem: async (name: string) => {
+    await localforage.removeItem(name)
+  },
+}))
+
+export const useNotesStore = create<NotesState>()(
+  persist(
+    (set) => ({
+      positionNotes: {},
+      storyletNotes: {},
+      hasHydrated: false,
+
+      addPositionNote: (id, partial) => {
+        const timestamp = nowIso()
+        const note: PositionNote = {
+          id,
+          body: partial.body ?? '',
+          color: partial.color,
+          tags: partial.tags ?? [],
+          createdAt: timestamp,
+          updatedAt: timestamp,
+        }
+        set((state) => ({
+          positionNotes: { ...state.positionNotes, [id]: note },
+        }))
+      },
+
+      updatePositionNote: (id, patch) => {
+        set((state) => {
+          const existing = state.positionNotes[id]
+          if (!existing) return state
+          const next: PositionNote = {
+            ...existing,
+            ...patch,
+            id: existing.id,
+            createdAt: existing.createdAt,
+            updatedAt: nowIso(),
+          }
+          return { positionNotes: { ...state.positionNotes, [id]: next } }
+        })
+      },
+
+      removePositionNote: (id) => {
+        set((state) => {
+          if (!(id in state.positionNotes)) return state
+          const next = { ...state.positionNotes }
+          delete next[id]
+          return { positionNotes: next }
+        })
+      },
+
+      addStoryletNote: (storyletId, note) => {
+        set((state) => {
+          const existing = state.storyletNotes[storyletId] ?? []
+          return {
+            storyletNotes: {
+              ...state.storyletNotes,
+              [storyletId]: [...existing, note],
+            },
+          }
+        })
+      },
+
+      updateStoryletNote: (storyletId, noteId, patch) => {
+        set((state) => {
+          const existing = state.storyletNotes[storyletId]
+          if (!existing) return state
+          const updated = existing.map((n) =>
+            n.id === noteId
+              ? {
+                  ...n,
+                  ...patch,
+                  id: n.id,
+                  storyletId: n.storyletId,
+                  createdAt: n.createdAt,
+                  updatedAt: nowIso(),
+                }
+              : n,
+          )
+          return {
+            storyletNotes: { ...state.storyletNotes, [storyletId]: updated },
+          }
+        })
+      },
+
+      removeStoryletNote: (storyletId, noteId) => {
+        set((state) => {
+          const existing = state.storyletNotes[storyletId]
+          if (!existing) return state
+          const filtered = existing.filter((n) => n.id !== noteId)
+          const nextMap = { ...state.storyletNotes }
+          if (filtered.length === 0) {
+            delete nextMap[storyletId]
+          } else {
+            nextMap[storyletId] = filtered
+          }
+          return { storyletNotes: nextMap }
+        })
+      },
+
+      removeAllNotesForStorylet: (storyletId) => {
+        set((state) => {
+          if (!(storyletId in state.storyletNotes)) return state
+          const next = { ...state.storyletNotes }
+          delete next[storyletId]
+          return { storyletNotes: next }
+        })
+      },
+
+      loadFromFile: (data) => {
+        set({
+          positionNotes: data.positionNotes,
+          storyletNotes: data.storyletNotes,
+        })
+      },
+
+      reset: () => {
+        set({ positionNotes: {}, storyletNotes: {} })
+      },
+    }),
+    {
+      name: 'writinator-notes',
+      version: 1,
+      storage: localforageStorage,
+      partialize: (state) =>
+        ({
+          positionNotes: state.positionNotes,
+          storyletNotes: state.storyletNotes,
+        }) as unknown as NotesState,
+      onRehydrateStorage: () => (_state, error) => {
+        if (error) {
+          console.error('[notesStore] rehydration error:', error)
+        }
+        useNotesStore.setState({ hasHydrated: true })
+      },
+    },
+  ),
+)
+
+if (import.meta.env.DEV) {
+  ;(globalThis as unknown as { __notesStore?: unknown }).__notesStore =
+    useNotesStore
+}
+
+// ---------------------------------------------------------------------------
+// File serialization helpers — used by fileSystem.ts section registry (Phase 2)
+// ---------------------------------------------------------------------------
+
+export function serializeNotes(): NotesFileData {
+  const { positionNotes, storyletNotes } = useNotesStore.getState()
+  return { positionNotes, storyletNotes }
+}
+
+export function hydrateNotes(data: NotesFileData | undefined): void {
+  if (data === undefined) return
+  useNotesStore.setState({
+    positionNotes: data.positionNotes,
+    storyletNotes: data.storyletNotes,
+  })
+}

--- a/src/stores/storyletStore.ts
+++ b/src/stores/storyletStore.ts
@@ -447,6 +447,15 @@ export const useStoryletStore = create<StoryletState>()(
           book: { ...book, storylets: remaining, updatedAt: now() },
           activeStoryletId: newActiveId,
         })
+        // Clean up storylet notes for each deleted storylet (dynamic import to
+        // avoid circular deps). Position notes are still owned by the markers
+        // embedded in content and are garbage-collected by Phase 9 consistency.
+        void import('./notesStore').then(({ useNotesStore }) => {
+          const removeAll = useNotesStore.getState().removeAllNotesForStorylet
+          for (const deletedId of toDelete) {
+            removeAll(deletedId)
+          }
+        })
       },
 
       reorderStorylets: (ids: string[]) => {

--- a/src/stores/storyletStore.ts
+++ b/src/stores/storyletStore.ts
@@ -34,6 +34,7 @@ import { useWriteathonStore, hydrateWriteathon } from './writeathonStore'
 import { useMetricsStore, hydrateMetrics } from './metricsStore'
 import { useCharacterStore } from './characterStore'
 import { hydratePlayer } from './playerStore'
+import { hydrateNotes } from './notesStore'
 import { countWords } from '../lib/words'
 
 interface StoryletState {
@@ -242,6 +243,7 @@ export const useStoryletStore = create<StoryletState>()(
         hydrateImageReveal(file.quests)
         hydrateWriteathon(file.writeathon)
         hydrateMetrics(file.metrics)
+        hydrateNotes(file.notes)
       },
 
       renameBook: (title: string) => {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -231,7 +231,7 @@ export interface NotesFileData {
 }
 
 export interface WritinatorFile {
-  version: 7
+  version: 8
   book: Book
   snapshots: Record<string, Snapshot[]>         // keyed by storylet ID
   publishedSnapshots: Record<string, PublishedSnapshot[]>  // keyed by storylet ID
@@ -239,11 +239,12 @@ export interface WritinatorFile {
   characters: Character[]
   markers: Record<string, StatDelta[]>          // keyed by marker UUID
   saveCounter: number
-  // Cross-store sections — optional for v1-v6 back-compat (absent = no-op on load)
+  // Cross-store sections — optional for back-compat (absent = no-op on load)
   player?: PlayerFileData
   quests?: ImageRevealFileData
   writeathon?: WriteathonFileData
   metrics?: MetricsFileData
+  notes?: NotesFileData
 }
 
 // ---------------------------------------------------------------------------

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -203,6 +203,33 @@ export interface MetricsFileData {
   pinnedMetrics: MetricKey[]
 }
 
+// ---------------------------------------------------------------------------
+// Notes — position notes anchored to storylet offsets, and per-storylet notes
+// ---------------------------------------------------------------------------
+
+export interface PositionNote {
+  id: string
+  body: string
+  color?: string
+  tags: string[]
+  createdAt: string
+  updatedAt: string
+}
+
+export interface StoryletNote {
+  id: string
+  storyletId: string
+  body: string
+  tags: string[]
+  createdAt: string
+  updatedAt: string
+}
+
+export interface NotesFileData {
+  positionNotes: Record<string, PositionNote>
+  storyletNotes: Record<string, StoryletNote[]>
+}
+
 export interface WritinatorFile {
   version: 7
   book: Book

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -456,6 +456,26 @@ export type ConsistencyIssue =
       markerId: string
     }
 
+export type NoteConsistencyIssue =
+  | {
+      /** Store has an entry for id, but no storylet.content contains the anchor. */
+      kind: 'orphanNote'
+      id: string
+      storyletId: undefined
+    }
+  | {
+      /** Content has an anchor for id, but no store entry exists. */
+      kind: 'inverseOrphanNote'
+      id: string
+      storyletId: string
+    }
+  | {
+      /** Store has storylet notes for a storyletId that no longer exists in the book. */
+      kind: 'orphanStoryletNote'
+      id: undefined
+      storyletId: string
+    }
+
 export interface RecentFile {
   handle: FileSystemFileHandle
   name: string

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -153,6 +153,8 @@ export type DocumentStyles = Record<string, NamedStyle>
 
 export const DEFAULT_STYLE_NAMES = ['body', 'h1', 'h2', 'h3', 'blockquote', 'code'] as const
 
+export type RightPanelTab = 'characters' | 'notes' | 'history'
+
 export interface EditorPreferences {
   vimMode: boolean
   fontFamily: 'serif' | 'sans' | 'mono'
@@ -161,6 +163,7 @@ export interface EditorPreferences {
   renderMode: 'source' | 'rendered' | 'preview'
   sidebarOpen: boolean
   collapsedStoryletIds: string[]
+  rightPanelActiveTab: RightPanelTab | null
 }
 
 export interface GlobalSettings {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -220,6 +220,7 @@ export interface StoryletNote {
   id: string
   storyletId: string
   body: string
+  color?: string
   tags: string[]
   createdAt: string
   updatedAt: string


### PR DESCRIPTION
Unify the three right-side panels (Characters, Notes, History) into a
single tabbed shell. When only one panel is open the shell drops the tab
bar so the solo-panel look matches the pre-tab UX; opening a second or
third panel slides in a tab bar with per-tab close-X. Active tab is
persisted via editorStore.rightPanelActiveTab and survives reload.

Each panel gained an optional embedded prop that strips its outer
wrapper + its own header when the shell supplies the chrome, so the
panels remain usable standalone too.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>